### PR TITLE
Handle case where entire openaddresses config is empty

### DIFF
--- a/import.js
+++ b/import.js
@@ -178,7 +178,7 @@ if( require.main === module ){
     process.exit( args.exitCode );
   }
   else {
-    var configFiles = peliasConfig.imports.openaddresses.files;
+    var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
     var files = (configFiles !== undefined && configFiles.length > 0) ?
       configFiles :
       fs.readdirSync( args.dirPath ).filter( function ( name ){

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pelias-admin-lookup": "^2.x.x",
     "pelias-logger": "^0.x.x",
     "minimist": "1.1.0",
-    "pelias-config": "^0.x.x",
+    "pelias-config": ">=0.2.0",
     "csv-parse": "0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This can happen on import when the user is specifying a directory of
files and hasn't set anything else up in pelias.json

Thanks to @amiller2978 for originally reporting this