### PR TITLE
Add cleanup module with numbered street handling

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -1,0 +1,12 @@
+function removeLeadingZerosFromStreet(token) {
+  return token.replace(/^(?:0*)([1-9]\d*(st|nd|rd|th))/,'$1');
+}
+
+function cleanupStreetName(input) {
+  var street_parts = input.split(' ');
+  return street_parts.map(removeLeadingZerosFromStreet).join(' ');
+}
+
+module.exports = {
+  streetName: cleanupStreetName
+};

--- a/lib/import_pipelines.js
+++ b/lib/import_pipelines.js
@@ -12,6 +12,7 @@ var through = require( 'through2' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var peliasModel = require( 'pelias-model' );
 var peliasDbclient = require( 'pelias-dbclient' );
+var cleanup = require( './cleanup' );
 
 function isValidCsvRecord( record ){
   return [ 'LON', 'LAT', 'NUMBER', 'STREET' ].reduce( function ( acc, prop ){
@@ -48,8 +49,9 @@ function createRecordStream( filePath ){
         var model_id = ( uid++ ).toString();
         var addrDoc;
         try {
+          var streetName = cleanup.streetName( record.STREET );
           addrDoc = new peliasModel.Document( 'openaddresses', model_id )
-            .setName( 'default', (record.NUMBER + ' ' + record.STREET).replace(/ +/g, ' ') )
+            .setName( 'default', (record.NUMBER + ' ' + streetName).replace(/ +/g, ' ') )
             .setCentroid( { lon: record.LON, lat: record.LAT } );
 
           try {
@@ -57,7 +59,7 @@ function createRecordStream( filePath ){
           } catch ( ex ) {}
 
           try {
-            addrDoc.setAddress( 'street', record.STREET );
+            addrDoc.setAddress( 'street', streetName );
           } catch ( ex ) {}
 
           try {


### PR DESCRIPTION
This cleanup code handles numbered streets with leading zeros. For
example, `05th Street` will become `5th street`. This code only operates
on numbers with ordinal suffixes, so a street named `06 street` would
not be changed.

I tested the regex by running it across all of openaddresses and comparing the before and after street names. In total, there were 52239 entries that change, with 135 unique types of changes. I looked at all [135 changes](https://github.com/pelias/openaddresses/files/87825/unique-changes.txt) and they look right. There are 11 files affected by the change:

```
us/ca/los_angeles.csv
us/ca/san_diego.csv
us/ca/san_francisco.csv
us/co/clear_creek.csv
us/ne/cherry.csv
us/ne/dakota.csv
us/ne/gage.csv
us/nm/bernalillo.csv
us/pa/philadelphia.csv
us/wi/statewide.csv
us/wy/albany.csv
```