### PR TITLE
[DO NOT MERGE] More async stream

### DIFF
--- a/import.js
+++ b/import.js
@@ -13,7 +13,7 @@ var minimist = require( 'minimist' );
 var combinedStream = require( 'combined-stream' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var addressDeduplicatorStream = require( 'pelias-address-deduplicator' );
-var peliasAdminLookup = require( 'pelias-admin-lookup' );
+var wofAdminLookup = require( 'pelias-wof-admin-lookup' );
 
 var importPipelines = require( './lib/import_pipelines' );
 
@@ -54,7 +54,8 @@ function importOpenAddressesFiles( files, opts ){
 
   if( opts.adminValues ){
     logger.info( 'Setting up admin value lookup stream.' );
-    var lookupStream = peliasAdminLookup.stream();
+    var resolver = wofAdminLookup.createWofPipResolver('http://localhost:8080');
+    var lookupStream = wofAdminLookup.createLookupStream(resolver);
     recordStream.pipe( lookupStream );
     recordStream = lookupStream;
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "pelias-logger": "^0.x.x",
     "pelias-model": "^0.x.x",
     "pelias-wof-admin-lookup": "file:../wof-admin-lookup",
-    "through2": "0.6.3"
+    "through2": "0.6.3",
+    "through2-sink": "^1.0.0"
   },
   "devDependencies": {
     "tape": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "glob": "^5.0.15",
     "minimist": "1.1.0",
     "pelias-address-deduplicator": "^1.x.x",
-    "pelias-admin-lookup": "^2.x.x",
     "pelias-config": ">=1.0.0",
     "pelias-dbclient": "^0.x.x",
     "pelias-logger": "^0.x.x",
     "pelias-model": "^0.x.x",
+    "pelias-wof-admin-lookup": "file:../wof-admin-lookup",
     "through2": "0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR uses pelias/wof-admin-lookup#6 to split the import process into two streams, allowing many parallel requests to the WOF point in polygon admin lookup service. It's a lot faster, but just a proof of concept.