### PR TITLE
Refactor parameters and stream creation

### DIFF
--- a/import.js
+++ b/import.js
@@ -4,17 +4,15 @@
 
 'use strict';
 
-var fs = require( 'fs' );
-var util = require( 'util' );
 var glob = require( 'glob' );
 
 var peliasConfig = require( 'pelias-config' ).generate();
-var minimist = require( 'minimist' );
 var combinedStream = require( 'combined-stream' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var addressDeduplicatorStream = require( 'pelias-address-deduplicator' );
 var peliasAdminLookup = require( 'pelias-admin-lookup' );
 
+var interpretUserArgs = require( './lib/interpretUserArgs' );
 var importPipelines = require( './lib/import_pipelines' );
 
 /**
@@ -74,118 +72,17 @@ function importOpenAddressesFiles( files, opts ){
   recordStream.pipe( esPipeline );
 }
 
-/**
- * Interprets the command-line arguments passed to the script.
- *
- * @param {array} argv Should be `process.argv.slice( 2 )`.
- * @return {object} If arguments were succesfully parsed, an object that can be
- *    used to call `importOpenAddressesDir`:
- *
- *      {
- *        dirPath: <string>,
- *        adminValues: <boolean>,
- *        deduplicate: <boolean>,
- *      }
- *
- *    Otherwise, an error object.
- *
- *      {
- *        exitCode: <number>,
- *        errMessage: <string>
- *      }
- */
-function interpretUserArgs( argv ){
-  var usageMessage = [
-    'A tool for importing OpenAddresses data into Pelias. Usage:',
-    '',
-    '\tnode import.js --help | [--deduplicate] [--admin-values] [OPENADDRESSES_DIR]',
-    '',
-    '',
-    '\t--help: Print this help message.',
-    '',
-    '\tOPENADDRESSES_DIR: A directory containing OpenAddresses CSV files.',
-    '\t\tIf none is specified, the path from your PELIAS_CONFIG\'s',
-    '\t\t`imports.openaddresses.datapath` will be used.',
-    '',
-    '\t--deduplicate: (advanced use) Deduplicate addresses using the',
-    '\t\tOpenVenues deduplicator: https://github.com/openvenues/address_deduper.',
-    '\t\tIt must be running at localhost:5000.',
-    '',
-    '\t--admin-values: (advanced use) OpenAddresses records lack admin values',
-    '\t\t(country, state, city, etc., names), so auto-fill them',
-    '\t\tusing `admin-lookup` See the documentation:',
-    '\t\thttps://github.com/pelias/admin-lookup'
-  ].join( '\n' );
+var args = interpretUserArgs.interpretUserArgs( process.argv.slice( 2 ) );
 
-  argv = minimist(
-    argv,
-    {
-      boolean: [ 'deduplicate', 'admin-values' ],
-      default: {
-        deduplicate: false,
-        'admin-values': false,
-      }
-    }
-  );
-
-  var validArgs = [ 'deduplicate', 'admin-values', 'help', '_' ];
-  for( var arg in argv ){
-    if( validArgs.indexOf( arg ) === -1 ){
-      return {
-        errMessage: util.format( '`%s` is not a recognized argument.', arg ),
-        exitCode: 1
-      };
-    }
-  }
-
-  if( argv.help ){
-    return { errMessage: usageMessage, exitCode: 0 };
-  }
-
-  var opts = {
-    deduplicate: argv.deduplicate,
-    adminValues: argv[ 'admin-values' ],
-    dirPath: null
-  };
-  if( argv._.length > 0 ){
-    opts.dirPath = argv._[ 0 ];
-  }
-  else {
-    opts.dirPath = peliasConfig.imports.openaddresses.datapath;
-  }
-
-  if( !fs.existsSync( opts.dirPath ) ){
-    return {
-      errMessage: util.format( 'Directory `%s` does not exist.', opts.dirPath ),
-      exitCode: 2
-    };
-  }
-  else if( !fs.statSync( opts.dirPath ).isDirectory() ){
-    return {
-      errMessage: util.format( '`%s` is not a directory.', opts.dirPath ),
-      exitCode: 2
-    };
-  }
-
-  return opts;
-}
-
-if( require.main === module ){
-  var args = interpretUserArgs( process.argv.slice( 2 ) );
-
-  if( 'exitCode' in args ){
-    ((args.exitCode > 0) ? console.error : console.info)( args.errMessage );
-    process.exit( args.exitCode );
-  }
-  else {
-    var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
-    var files = (configFiles !== undefined && configFiles.length > 0) ?
-      configFiles :
-      glob.sync( args.dirPath + '/**/*.csv' );
-
-    importOpenAddressesFiles( files, args );
-  }
+if( 'exitCode' in args ){
+  ((args.exitCode > 0) ? console.error : console.info)( args.errMessage );
+  process.exit( args.exitCode );
 }
 else {
-  module.exports = interpretUserArgs; // for tests
+  var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
+  var files = (configFiles !== undefined && configFiles.length > 0) ?
+    configFiles :
+      glob.sync( args.dirPath + '/**/*.csv' );
+
+      importOpenAddressesFiles( files, args );
 }

--- a/import.js
+++ b/import.js
@@ -4,8 +4,6 @@
 
 'use strict';
 
-var glob = require( 'glob' );
-
 var peliasConfig = require( 'pelias-config' ).generate();
 var combinedStream = require( 'combined-stream' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
@@ -79,10 +77,7 @@ if( 'exitCode' in args ){
   process.exit( args.exitCode );
 }
 else {
-  var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
-  var files = (configFiles !== undefined && configFiles.length > 0) ?
-    configFiles :
-      glob.sync( args.dirPath + '/**/*.csv' );
+  var files = interpretUserArgs.getFileList(peliasConfig, args);
 
-      importOpenAddressesFiles( files, args );
+  importOpenAddressesFiles( files, args );
 }

--- a/import.js
+++ b/import.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var peliasConfig = require( 'pelias-config' ).generate();
-var combinedStream = require( 'combined-stream' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var addressDeduplicatorStream = require( 'pelias-address-deduplicator' );
 var peliasAdminLookup = require( 'pelias-admin-lookup' );
@@ -29,15 +28,8 @@ var importPipelines = require( './lib/import_pipelines' );
  *        documentation: https://github.com/pelias/admin-lookup
  */
 function importOpenAddressesFiles( files, opts ){
-  var recordStream = combinedStream.create();
-
   logger.info( 'Importing %s files.', files.length );
-  files.forEach( function forEach( filePath ){
-    recordStream.append( function ( next ){
-      logger.info( 'Creating read stream for: ' + filePath );
-      next( importPipelines.createRecordStream( filePath ) );
-    });
-  });
+  var recordStream = importPipelines.createFullRecordStream(files);
 
   var esPipeline = importPipelines.createPeliasElasticsearchPipeline();
 

--- a/import.js
+++ b/import.js
@@ -32,7 +32,7 @@ function startTiming() {
  *        to perform deduplication. See the documentation:
  *        https://github.com/pelias/address-deduplicator-stream
  *
- *      admin-values: Add admin values to each address object (since
+ *      adminValues: Add admin values to each address object (since
  *        OpenAddresses doesn't contain any) using `admin-lookup`. See the
  *        documentation: https://github.com/pelias/admin-lookup
  */

--- a/lib/import_pipelines.js
+++ b/lib/import_pipelines.js
@@ -16,6 +16,8 @@ var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var peliasModel = require( 'pelias-model' );
 var peliasDbclient = require( 'pelias-dbclient' );
 var cleanup = require( './cleanupStream' );
+var peliasAdminLookup = require( 'pelias-admin-lookup' );
+var addressDeduplicatorStream = require( 'pelias-address-deduplicator' );
 
 /*
  * Return true if a record has all of LON, LAT, NUMBER and STREET defined
@@ -168,10 +170,22 @@ function createFullRecordStream(files) {
   return recordStream;
 }
 
+function createDeduplicatorStream() {
+  logger.info( 'Setting up deduplicator.' );
+  return addressDeduplicatorStream();
+}
+
+function createAdminLookupStream() {
+  logger.info( 'Setting up admin value lookup stream.' );
+  return peliasAdminLookup.stream();
+}
+
 module.exports = {
   createRecordStream: createRecordStream,
   createPeliasElasticsearchPipeline: createPeliasElasticsearchPipeline,
   isValidCsvRecord: isValidCsvRecord,
   createDocumentStream: createDocumentStream,
-  createFullRecordStream: createFullRecordStream
+  createFullRecordStream: createFullRecordStream,
+  createDeduplicatorStream: createDeduplicatorStream,
+  createAdminLookupStream: createAdminLookupStream
 };

--- a/lib/import_pipelines.js
+++ b/lib/import_pipelines.js
@@ -7,8 +7,11 @@
 'use strict';
 
 var fs = require( 'fs' );
+
+var combinedStream = require( 'combined-stream' );
 var csvParse = require( 'csv-parse' );
 var through = require( 'through2' );
+
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 var peliasModel = require( 'pelias-model' );
 var peliasDbclient = require( 'pelias-dbclient' );
@@ -149,9 +152,26 @@ function createPeliasElasticsearchPipeline(){
   return entryPoint;
 }
 
+/*
+ * Create a single stream from many CSV files
+ */
+function createFullRecordStream(files) {
+  var recordStream = combinedStream.create();
+
+  files.forEach( function forEach( filePath ){
+    recordStream.append( function ( next ){
+      logger.info( 'Creating read stream for: ' + filePath );
+      next(createRecordStream( filePath ) );
+    });
+  });
+
+  return recordStream;
+}
+
 module.exports = {
   createRecordStream: createRecordStream,
   createPeliasElasticsearchPipeline: createPeliasElasticsearchPipeline,
   isValidCsvRecord: isValidCsvRecord,
-  createDocumentStream: createDocumentStream
+  createDocumentStream: createDocumentStream,
+  createFullRecordStream: createFullRecordStream
 };

--- a/lib/interpretUserArgs.js
+++ b/lib/interpretUserArgs.js
@@ -1,0 +1,106 @@
+var fs = require( 'fs' );
+var util = require( 'util' );
+var minimist = require( 'minimist' );
+
+var peliasConfig = require( 'pelias-config' ).generate();
+
+/**
+ * Interprets the command-line arguments passed to the script.
+ *
+ * @param {array} argv Should be `process.argv.slice( 2 )`.
+ * @return {object} If arguments were succesfully parsed, an object that can be
+ *    used to call `importOpenAddressesDir`:
+ *
+ *      {
+ *        dirPath: <string>,
+ *        adminValues: <boolean>,
+ *        deduplicate: <boolean>,
+ *      }
+ *
+ *    Otherwise, an error object.
+ *
+ *      {
+ *        exitCode: <number>,
+ *        errMessage: <string>
+ *      }
+ */
+function interpretUserArgs( argv ){
+  var usageMessage = [
+    'A tool for importing OpenAddresses data into Pelias. Usage:',
+    '',
+    '\tnode import.js --help | [--deduplicate] [--admin-values] [OPENADDRESSES_DIR]',
+    '',
+    '',
+    '\t--help: Print this help message.',
+    '',
+    '\tOPENADDRESSES_DIR: A directory containing OpenAddresses CSV files.',
+    '\t\tIf none is specified, the path from your PELIAS_CONFIG\'s',
+    '\t\t`imports.openaddresses.datapath` will be used.',
+    '',
+    '\t--deduplicate: (advanced use) Deduplicate addresses using the',
+    '\t\tOpenVenues deduplicator: https://github.com/openvenues/address_deduper.',
+    '\t\tIt must be running at localhost:5000.',
+    '',
+    '\t--admin-values: (advanced use) OpenAddresses records lack admin values',
+    '\t\t(country, state, city, etc., names), so auto-fill them',
+    '\t\tusing `admin-lookup` See the documentation:',
+    '\t\thttps://github.com/pelias/admin-lookup'
+  ].join( '\n' );
+
+  argv = minimist(
+    argv,
+    {
+      boolean: [ 'deduplicate', 'admin-values' ],
+      default: {
+        deduplicate: false,
+        'admin-values': false,
+      }
+    }
+  );
+
+  var validArgs = [ 'deduplicate', 'admin-values', 'help', '_' ];
+  for( var arg in argv ){
+    if( validArgs.indexOf( arg ) === -1 ){
+      return {
+        errMessage: util.format( '`%s` is not a recognized argument.', arg ),
+        exitCode: 1
+      };
+    }
+  }
+
+  if( argv.help ){
+    return { errMessage: usageMessage, exitCode: 0 };
+  }
+
+  var opts = {
+    deduplicate: argv.deduplicate,
+    adminValues: argv[ 'admin-values' ],
+    dirPath: null
+  };
+  if( argv._.length > 0 ){
+    opts.dirPath = argv._[ 0 ];
+  }
+  else {
+    opts.dirPath = peliasConfig.imports.openaddresses.datapath;
+  }
+
+  if( !fs.existsSync( opts.dirPath ) ){
+    return {
+      errMessage: util.format( 'Directory `%s` does not exist.', opts.dirPath ),
+      exitCode: 2
+    };
+  }
+  else if( !fs.statSync( opts.dirPath ).isDirectory() ){
+    return {
+      errMessage: util.format( '`%s` is not a directory.', opts.dirPath ),
+      exitCode: 2
+    };
+  }
+
+  return opts;
+
+}
+
+module.exports = {
+  interpretUserArgs: interpretUserArgs
+};

--- a/lib/interpretUserArgs.js
+++ b/lib/interpretUserArgs.js
@@ -1,6 +1,7 @@
 var fs = require( 'fs' );
 var util = require( 'util' );
 var glob = require( 'glob' );
+var path = require( 'path' );
 
 var minimist = require( 'minimist' );
 
@@ -107,10 +108,13 @@ function interpretUserArgs( argv, config ){
 
 function getFileList(peliasConfig, args) {
   var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
-  var files = (configFiles !== undefined && configFiles.length > 0) ?
-    configFiles :
-      glob.sync( args.dirPath + '/**/*.csv' );
-  return files;
+  if (configFiles !== undefined && configFiles.length > 0) {
+    return configFiles.map(function(file) {
+      return path.join(args.dirPath, file);
+    });
+  } else {
+    return glob.sync( args.dirPath + '/**/*.csv' );
+  }
 }
 
 module.exports = {

--- a/lib/interpretUserArgs.js
+++ b/lib/interpretUserArgs.js
@@ -24,7 +24,9 @@ var peliasConfig = require( 'pelias-config' ).generate();
  *        errMessage: <string>
  *      }
  */
-function interpretUserArgs( argv ){
+function interpretUserArgs( argv, config ){
+  config = config || peliasConfig;
+
   var usageMessage = [
     'A tool for importing OpenAddresses data into Pelias. Usage:',
     '',
@@ -81,7 +83,7 @@ function interpretUserArgs( argv ){
     opts.dirPath = argv._[ 0 ];
   }
   else {
-    opts.dirPath = peliasConfig.imports.openaddresses.datapath;
+    opts.dirPath = config.imports.openaddresses.datapath;
   }
 
   if( !fs.existsSync( opts.dirPath ) ){

--- a/lib/interpretUserArgs.js
+++ b/lib/interpretUserArgs.js
@@ -1,5 +1,7 @@
 var fs = require( 'fs' );
 var util = require( 'util' );
+var glob = require( 'glob' );
+
 var minimist = require( 'minimist' );
 
 var peliasConfig = require( 'pelias-config' ).generate();
@@ -103,6 +105,15 @@ function interpretUserArgs( argv, config ){
 
 }
 
+function getFileList(peliasConfig, args) {
+  var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
+  var files = (configFiles !== undefined && configFiles.length > 0) ?
+    configFiles :
+      glob.sync( args.dirPath + '/**/*.csv' );
+  return files;
+}
+
 module.exports = {
-  interpretUserArgs: interpretUserArgs
+  interpretUserArgs: interpretUserArgs,
+  getFileList: getFileList
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "jshint": "2.5.11",
     "precommit-hook": "1.0.7",
     "tap-spec": "2.1.2",
-    "tape": "3.0.3"
+    "tape": "3.0.3",
+    "temp": "^0.8.3"
   },
   "scripts": {
     "import": "node import.js",

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,5 +1,6 @@
 var tape = require( 'tape' );
 var util = require( 'util' );
+var path = require( 'path' );
 
 var temp = require( 'temp' ).track();
 
@@ -69,6 +70,28 @@ tape('interpretUserArgs returns dir from pelias config if no dir specified on co
     var result = interpretUserArgs.interpretUserArgs(input, peliasConfig);
 
     test.equal(result.dirPath, temporary_dir, 'path should be equal to path from config');
+    test.end();
+  });
+});
+
+tape('getFileList returns fully qualified path names when config has a files list', function(test) {
+  temp.mkdir('multipleFiles', function(err, temporary_dir) {
+    var peliasConfig = {
+      imports: {
+        openaddresses: {
+          files: ['filea.csv', 'fileb.csv']
+        }
+      }
+    };
+    var args = {
+      dirPath: temporary_dir
+    };
+
+    var expected = [path.join(temporary_dir, 'filea.csv'), path.join(temporary_dir, 'fileb.csv')];
+
+    var actual = interpretUserArgs.getFileList(peliasConfig, args);
+
+    test.deepEqual(actual, expected, 'file names should be equal');
     test.end();
   });
 });

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -54,3 +54,21 @@ tape('interpretUserArgs returns given path as dirPath', function(test) {
     test.end();
   });
 });
+
+tape('interpretUserArgs returns dir from pelias config if no dir specified on command line', function(test) {
+  temp.mkdir('tmpdir2', function(err, temporary_dir) {
+    var peliasConfig = {
+      imports: {
+        openaddresses: {
+          datapath: temporary_dir
+        }
+      }
+    };
+
+    var input = [];
+    var result = interpretUserArgs.interpretUserArgs(input, peliasConfig);
+
+    test.equal(result.dirPath, temporary_dir, 'path should be equal to path from config');
+    test.end();
+  });
+});

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,6 +1,7 @@
 var tape = require( 'tape' );
 var util = require( 'util' );
-var os = require( 'os' );
+
+var temp = require( 'temp' ).track();
 
 var interpretUserArgs = require( '../lib/interpretUserArgs' );
 
@@ -44,11 +45,12 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
 });
 
 tape('interpretUserArgs returns given path as dirPath', function(test) {
-  var dir_that_exists = os.tmpdir();
+  temp.mkdir('tmpdir', function(err, temporary_dir) {
 
-  var input = [dir_that_exists];
-  var result = interpretUserArgs.interpretUserArgs(input);
+    var input = [temporary_dir];
+    var result = interpretUserArgs.interpretUserArgs(input);
 
-  test.equal(result.dirPath, dir_that_exists, 'path should be equal to specified path');
-  test.end();
+    test.equal(result.dirPath, temporary_dir, 'path should be equal to specified path');
+    test.end();
+  });
 });

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,5 +1,6 @@
 var tape = require( 'tape' );
 var util = require( 'util' );
+var os = require( 'os' );
 
 var interpretUserArgs = require( '../lib/interpretUserArgs' );
 
@@ -39,5 +40,15 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
       'Invalid arguments yield an error object: ' + ind
     );
   });
+  test.end();
+});
+
+tape('interpretUserArgs returns given path as dirPath', function(test) {
+  var dir_that_exists = os.tmpdir();
+
+  var input = [dir_that_exists];
+  var result = interpretUserArgs.interpretUserArgs(input);
+
+  test.equal(result.dirPath, dir_that_exists, 'path should be equal to specified path');
   test.end();
 });

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,7 +1,7 @@
 var tape = require( 'tape' );
 var util = require( 'util' );
 
-var importScript = require( '../import' );
+var interpretUserArgs = require( '../lib/interpretUserArgs' );
 
 tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
   var testCases = [
@@ -21,7 +21,7 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
 
   testCases.forEach( function execTestCase( testCase, ind ){
     test.deepEqual(
-      importScript( testCase[ 0 ] ), testCase[ 1 ],
+      interpretUserArgs.interpretUserArgs( testCase[ 0 ] ), testCase[ 1 ],
       util.format( 'Arguments case %d passes.', ind )
     );
   });
@@ -33,7 +33,7 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
     [ '--deduplicate', 'package.json' ],
   ];
   badArguments.forEach( function execTestCase( testCase, ind ){
-    var errorObj = importScript( testCase );
+    var errorObj = interpretUserArgs.interpretUserArgs( testCase );
     test.ok(
       'exitCode' in errorObj &&  'errMessage' in errorObj,
       'Invalid arguments yield an error object: ' + ind
@@ -41,4 +41,3 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
   });
   test.end();
 });
-


### PR DESCRIPTION
Another refactoring branch!

This one...
* separates out much of the code for handling command line parameters
* adds tests, and notably fixes the long standing bug #23 when specifying many files in pelias config
* separates all the logic around creating and initializing the streams that go into the import pipeline. this will make swapping out pipeline components much easier

Fixes pelias/pelias#228