### PR TITLE
Check correct columns exist before checking length

### DIFF
--- a/lib/isValidCsvRecord.js
+++ b/lib/isValidCsvRecord.js
@@ -3,7 +3,7 @@
  */
 function isValidCsvRecord( record ){
   return [ 'LON', 'LAT', 'NUMBER', 'STREET' ].every(function(prop) {
-    return record[ prop ].length > 0;
+    return record[ prop ] && record[ prop ].length > 0;
   });
 }
 

--- a/test/isValidCsvRecord.js
+++ b/test/isValidCsvRecord.js
@@ -16,3 +16,10 @@ tape( 'Identifies invalid CSV records.', function ( test ){
   test.ok( isValidCsvRecord( validRecord ), 'Record identified as valid.' );
   test.end();
 });
+
+tape( 'Identifies CSV files that have incorrect columns', function( test) {
+  var record = { 'notLat': 'asdf', 'notLon': 5 };
+
+  test.ok( !isValidCsvRecord( record ), 'Record identified as invalid' );
+  test.end();
+});


### PR DESCRIPTION
This protects the importer from files that are not at all valid OA data
files. That is, files with totally incorrect columns will essentially be
ignored, instead of causing the importer to crash.

Fixes #60 