### PR TITLE
Parallel imports

### DIFF
--- a/bin/parallel
+++ b/bin/parallel
@@ -1,13 +1,21 @@
 #!/bin/bash
 
+# grab the number of workers count
 count=$1
+
+# remove the first argument from the arguments array ($@)
 shift
 
+# only do anything if count is a valid integer >= 1
 if [[ $count -ge 1 ]]; then
 	echo "starting $count parallel builds"
+
+	# spawn $count parallel builds, passing correct params and all arguments
 	for i in `seq 0 $(($count-1))`; do
 		cmd="node import.js --parallel-count $count --parallel-id $i $@ "
 		$cmd &
 	done
+
+	# don't let this script finish until all parallel builds have finished
 	wait
 fi

--- a/bin/parallel
+++ b/bin/parallel
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+count=$1
+shift
+
+if [[ $count -ge 1 ]]; then
+	echo "starting $count parallel builds"
+	for i in `seq 0 $(($count-1))`; do
+		cmd="node import.js --parallel-count $count --parallel-id $i $@ "
+		$cmd &
+	done
+	wait
+fi

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -124,7 +124,7 @@ function getFullFileList(peliasConfig, args) {
 function getFileList(peliasConfig, args) {
   var files = getFullFileList(peliasConfig, args);
 
-  if (args['parallel-count'] > 0 && args['parallel-id'] > 0) {
+  if (args['parallel-count'] > 0 && args['parallel-id'] >= 0) {
     files = files.filter(function(element, index) {
       return index % args['parallel-count'] === args['parallel-id'];
     });

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -63,7 +63,7 @@ function interpretUserArgs( argv, config ){
     }
   );
 
-  var validArgs = [ 'deduplicate', 'admin-values', 'help', '_' ];
+  var validArgs = [ 'deduplicate', 'admin-values', 'help', '_', 'parallel-count', 'parallel-id' ];
   for( var arg in argv ){
     if( validArgs.indexOf( arg ) === -1 ){
       return {
@@ -80,6 +80,8 @@ function interpretUserArgs( argv, config ){
   var opts = {
     deduplicate: argv.deduplicate,
     adminValues: argv[ 'admin-values' ],
+    'parallel-count': argv['parallel-count'],
+    'parallel-id': argv['parallel-id'],
     dirPath: null
   };
   if( argv._.length > 0 ){
@@ -108,7 +110,7 @@ function interpretUserArgs( argv, config ){
 
 }
 
-function getFileList(peliasConfig, args) {
+function getFullFileList(peliasConfig, args) {
   var configFiles = peliasConfig.imports.openaddresses? peliasConfig.imports.openaddresses.files : undefined;
   if (configFiles !== undefined && configFiles.length > 0) {
     return configFiles.map(function(file) {
@@ -117,6 +119,18 @@ function getFileList(peliasConfig, args) {
   } else {
     return glob.sync( args.dirPath + '/**/*.csv' );
   }
+}
+
+function getFileList(peliasConfig, args) {
+  var files = getFullFileList(peliasConfig, args);
+
+  if (args['parallel-count'] > 0 && args['parallel-id'] > 0) {
+    files = files.filter(function(element, index) {
+      return index % args['parallel-count'] === args['parallel-id'];
+    });
+  }
+
+  return files;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "import": "node import.js",
+    "parallel": "./bin/parallel",
     "test": "npm run units",
     "units": "node test/test.js | tap-spec",
     "functional": "node test/functional.js | tap-spec",

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -139,6 +139,21 @@ tape('getFileList handles parallel builds', function(test) {
   };
 
   temp.mkdir('parallelBuilds', function(err, temporary_dir) {
+    test.test('3 workers, id 0', function(t) {
+      var args = {
+        dirPath: temporary_dir,
+        'parallel-count': 3,
+        'parallel-id': 0
+      };
+
+      var expected = [path.join(temporary_dir, 'filea.csv')];
+
+      var actual = parameters.getFileList(peliasConfig, args);
+
+      t.deepEqual(actual, expected, 'only first file is indexed');
+      t.end();
+    });
+
     test.test('3 workers, id 1', function(t) {
       var args = {
         dirPath: temporary_dir,

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -10,15 +10,15 @@ tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
   var testCases = [
     [
       [ '--deduplicate', '--admin-values', 'test'  ],
-      { deduplicate: true, adminValues: true, dirPath: 'test' },
+      { deduplicate: true, adminValues: true, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined },
     ],
     [
       [ '--admin-values', 'test' ],
-      { deduplicate: false, adminValues: true, dirPath: 'test' },
+      { deduplicate: false, adminValues: true, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined },
     ],
     [
       [ '--deduplicate', 'test' ],
-      { deduplicate: true, adminValues: false, dirPath: 'test' },
+      { deduplicate: true, adminValues: false, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined},
     ]
   ];
 
@@ -126,5 +126,62 @@ tape('getFileList returns fully qualified path names when config has a files lis
 
     test.deepEqual(actual, expected, 'file names should be equal');
     test.end();
+  });
+});
+
+tape('getFileList handles parallel builds', function(test) {
+  var peliasConfig = {
+    imports: {
+      openaddresses: {
+        files: ['filea.csv', 'fileb.csv', 'filec.csv']
+      }
+    }
+  };
+
+  temp.mkdir('parallelBuilds', function(err, temporary_dir) {
+    test.test('3 workers, id 1', function(t) {
+      var args = {
+        dirPath: temporary_dir,
+        'parallel-count': 3,
+        'parallel-id': 1
+      };
+
+      var expected = [path.join(temporary_dir, 'fileb.csv')];
+
+      var actual = parameters.getFileList(peliasConfig, args);
+
+      t.deepEqual(actual, expected, 'only second file indexed');
+      t.end();
+    });
+
+    test.test('3 workers, id 2', function(t) {
+      var args = {
+        dirPath: temporary_dir,
+        'parallel-count': 3,
+        'parallel-id': 2
+      };
+
+      var expected = [path.join(temporary_dir, 'filec.csv')];
+
+      var actual = parameters.getFileList(peliasConfig, args);
+
+      t.deepEqual(actual, expected, 'only third file indexed');
+      t.end();
+    });
+
+    test.test('3 workers, id 3', function(t) {
+      var args = {
+        dirPath: temporary_dir,
+        'parallel-count': 3,
+        'parallel-id': 3
+      };
+
+      var expected = [];
+
+      var actual = parameters.getFileList(peliasConfig, args);
+
+      t.deepEqual(actual, expected, 'file list is empty');
+      t.end();
+    });
   });
 });


### PR DESCRIPTION
This PR adds some parameters to the OA importer, as well as a bash script, to allow easily starting multiple OA importers that will run in parallel to import multiple files faster.

## How it works

The importer now accepts two new command line parameters: `--parallel-count [integer]` and `--parallel-id [integer]`. If either of these aren't a valid number, nothing about the behavior of the importer will change.

If both ARE specified, then an additional step is added to the process of determining what CSV files to import. Normally, the importer is given either a list of files to import, or a directory, in which case it will find all CSV files in that directory and import each one sequentially. Either way, internally the importer is working through an array of files to import.

With both the above parameters specified, the importer filters this array of files by the modulus of the index of each element. So if `parallel-count` is 3 and `parallel-id` is 0, the importer will only import the 1st, 4th, 7th, etc files. with `parallel-count` 4 and `parallel-id 2` it would import the 3rd, 7th, 11th, etc.

There's also a new bin directory added with a bash script. This script expects an integer as the first parameter, and it will launch that many instances of the importer, with the `--parallel-count` and `--parallel-id` params set so they share the work. Any parameters after the first, it passes on to each importer.