### PR TITLE
Filter out literal word `null` and `undefined`

### DIFF
--- a/lib/isValidCsvRecord.js
+++ b/lib/isValidCsvRecord.js
@@ -1,7 +1,29 @@
+var _ = require('lodash');
+
 /*
  * Return true if a record has all of LON, LAT, NUMBER and STREET defined
  */
 function isValidCsvRecord( record ){
+  return hasAllProperties(record) &&
+          !houseNumberIsLiteralWordNull(record) &&
+          !streetContainsLiteralWordNull(record);
+}
+
+/*
+ * Return false if record.NUMBER is literal word 'NULL' (case-insensitive)
+*/
+function houseNumberIsLiteralWordNull(record) {
+  return _.toUpper(record['NUMBER']) === 'NULL';
+}
+
+/*
+ * Return false if record.STREET contains literal word 'NULL' (case-insensitive)
+*/
+function streetContainsLiteralWordNull(record) {
+  return /\bnull\b/i.test(record['STREET']);
+}
+
+function hasAllProperties(record) {
   return [ 'LON', 'LAT', 'NUMBER', 'STREET' ].every(function(prop) {
     return record[ prop ] && record[ prop ].length > 0;
   });

--- a/lib/isValidCsvRecord.js
+++ b/lib/isValidCsvRecord.js
@@ -5,30 +5,24 @@ var _ = require('lodash');
  */
 function isValidCsvRecord( record ){
   return hasAllProperties(record) &&
-          !houseNumberIsLiteralWordNull(record) &&
-          !streetContainsLiteralWordNull(record) &&
-          !streetIsLiteralWordUndefined(record);
+          !houseNumberIsExclusionaryWord(record) &&
+          !streetContainsExclusionaryWord(record);
 }
 
 /*
- * Return false if record.NUMBER is literal word 'NULL' (case-insensitive)
+ * Return false if record.NUMBER is literal word 'NULL', 'UNDEFINED',
+ * or 'UNAVAILABLE' (case-insensitive)
 */
-function houseNumberIsLiteralWordNull(record) {
-  return _.toUpper(record['NUMBER']) === 'NULL';
+function houseNumberIsExclusionaryWord(record) {
+  return ['NULL', 'UNDEFINED', 'UNAVAILABLE'].indexOf(_.toUpper(record['NUMBER'])) !== -1;
 }
 
 /*
- * Return false if record.STREET contains literal word 'NULL' (case-insensitive)
+ * Return false if record.STREET contains literal word 'NULL', 'UNDEFINED',
+ * or 'UNAVAILABLE' (case-insensitive)
 */
-function streetContainsLiteralWordNull(record) {
-  return /\bnull\b/i.test(record['STREET']);
-}
-
-/*
- * Return false if record.STREET is literal word 'UNDEFINED' (case-insensitive)
-*/
-function streetIsLiteralWordUndefined(record) {
-  return _.toUpper(record['STREET']) === 'UNDEFINED';
+function streetContainsExclusionaryWord(record) {
+  return /\b(NULL|UNDEFINED|UNAVAILABLE)\b/i.test(record['STREET']);
 }
 
 function hasAllProperties(record) {

--- a/lib/isValidCsvRecord.js
+++ b/lib/isValidCsvRecord.js
@@ -6,7 +6,8 @@ var _ = require('lodash');
 function isValidCsvRecord( record ){
   return hasAllProperties(record) &&
           !houseNumberIsLiteralWordNull(record) &&
-          !streetContainsLiteralWordNull(record);
+          !streetContainsLiteralWordNull(record) &&
+          !streetIsLiteralWordUndefined(record);
 }
 
 /*
@@ -21,6 +22,13 @@ function houseNumberIsLiteralWordNull(record) {
 */
 function streetContainsLiteralWordNull(record) {
   return /\bnull\b/i.test(record['STREET']);
+}
+
+/*
+ * Return false if record.STREET is literal word 'UNDEFINED' (case-insensitive)
+*/
+function streetIsLiteralWordUndefined(record) {
+  return _.toUpper(record['STREET']) === 'UNDEFINED';
 }
 
 function hasAllProperties(record) {

--- a/test/isValidCsvRecord.js
+++ b/test/isValidCsvRecord.js
@@ -24,7 +24,7 @@ tape( 'Identifies CSV files that have incorrect columns', function( test) {
   test.end();
 });
 
-tape('complete record but house number is literal word null should return false', function(test) {
+tape('complete record but house number is literal word `null` should return false', function(test) {
   var record = {
     LON: '1', LAT: '2', NUMBER: 'NuLl', STREET: 'Street'
   }
@@ -34,7 +34,27 @@ tape('complete record but house number is literal word null should return false'
 
 });
 
-tape('complete record but street contains literal word null should return false', function(test) {
+tape('complete record but house number is literal word `undefined` should return false', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'uNdEfInEd', STREET: 'Street'
+  }
+
+  test.ok( !isValidCsvRecord(record), 'Record identified as invalid');
+  test.end();
+
+});
+
+tape('complete record but house number is literal word `unavailable` should return false', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'uNaVaIlAbLe', STREET: 'Street'
+  }
+
+  test.ok( !isValidCsvRecord(record), 'Record identified as invalid');
+  test.end();
+
+});
+
+tape('complete record but street contains literal word `null` should return false', function(test) {
   var records = [
     { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'NuLl Name St' },
     { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South NULL St' },
@@ -49,7 +69,37 @@ tape('complete record but street contains literal word null should return false'
 
 });
 
-tape('street with substring null but not on word boundary should return true', function(test) {
+tape('complete record but street contains literal word `undefined` should return false', function(test) {
+  var records = [
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'uNdEfInEd Name St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South UNDEFINED St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South Name undefined' }
+  ];
+
+  records.forEach( function ( rec ){
+    test.ok( !isValidCsvRecord( rec ), 'Record identified as invalid' );
+  });
+
+  test.end();
+
+});
+
+tape('complete record but street contains literal word `unavailable` should return false', function(test) {
+  var records = [
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'uNaVaIlAbLe Name St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South UNAVAILABLE St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South Name unavailable' }
+  ];
+
+  records.forEach( function ( rec ){
+    test.ok( !isValidCsvRecord( rec ), 'Record identified as invalid' );
+  });
+
+  test.end();
+
+});
+
+tape('street with substring `null` but not on word boundary should return true', function(test) {
   var record = {
     LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'Snull Street Nulls'
   }
@@ -59,12 +109,22 @@ tape('street with substring null but not on word boundary should return true', f
 
 });
 
-tape('street value `undefined` should return false', function(test) {
+tape('street with substring `undefined` but not on word boundary should return true', function(test) {
   var record = {
-    LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'uNdEfInEd'
+    LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'Sundefined Street Undefineds'
   }
 
-  test.ok( !isValidCsvRecord(record), 'Record identified as valid');
+  test.ok( isValidCsvRecord(record), 'Record identified as valid');
+  test.end();
+
+});
+
+tape('street with substring `unavailable` but not on word boundary should return true', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'Sunavailable Street Unavailables'
+  }
+
+  test.ok( isValidCsvRecord(record), 'Record identified as valid');
   test.end();
 
 });

--- a/test/isValidCsvRecord.js
+++ b/test/isValidCsvRecord.js
@@ -58,3 +58,13 @@ tape('street with substring null but not on word boundary should return true', f
   test.end();
 
 });
+
+tape('street value `undefined` should return false', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'uNdEfInEd'
+  }
+
+  test.ok( !isValidCsvRecord(record), 'Record identified as valid');
+  test.end();
+
+});

--- a/test/isValidCsvRecord.js
+++ b/test/isValidCsvRecord.js
@@ -23,3 +23,38 @@ tape( 'Identifies CSV files that have incorrect columns', function( test) {
   test.ok( !isValidCsvRecord( record ), 'Record identified as invalid' );
   test.end();
 });
+
+tape('complete record but house number is literal word null should return false', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'NuLl', STREET: 'Street'
+  }
+
+  test.ok( !isValidCsvRecord(record), 'Record identified as invalid');
+  test.end();
+
+});
+
+tape('complete record but street contains literal word null should return false', function(test) {
+  var records = [
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'NuLl Name St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South NULL St' },
+    { LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'South Name null' }
+  ];
+
+  records.forEach( function ( rec ){
+    test.ok( !isValidCsvRecord( rec ), 'Record identified as invalid' );
+  });
+
+  test.end();
+
+});
+
+tape('street with substring null but not on word boundary should return true', function(test) {
+  var record = {
+    LON: '1', LAT: '2', NUMBER: 'Number', STREET: 'Snull Street Nulls'
+  }
+
+  test.ok( isValidCsvRecord(record), 'Record identified as valid');
+  test.end();
+
+});


### PR DESCRIPTION
Fixed pelias/pelias#127 (at least for OA)

Records are filtered out in the following conditions:

- `NUMBER` field value is literal word `NULL` (case insensitive)
- `STREET` field value contains literal word `NULL` on word boundary
- `STREET` field value is literal word `UNDEFINED` (case insensitive)