### PR TITLE
Remove Node 0.10 from Travis versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - 0.10
   - 0.12
   - 4
   - 5


### PR DESCRIPTION
We are beginning to officially depricate it.