### PR TITLE
Fix linter errors

### DIFF
--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -19,7 +19,7 @@ var isUSorCAHouseNumberZero = require( './streams/isUSorCAHouseNumberZero' );
  *        OpenAddresses doesn't contain any) using `admin-lookup`. See the
  *        documentation: https://github.com/pelias/admin-lookup
  */
-function createFullImportPipeline( files, dirPath, deduplicatorStream, adminLookupStream, finalStream ){
+function createFullImportPipeline( files, dirPath, deduplicatorStream, adminLookupStream, finalStream ){ // jshint ignore:line
   logger.info( 'Importing %s files.', files.length );
 
   finalStream = finalStream || peliasDbclient();

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -1,5 +1,4 @@
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
-var peliasConfig = require( 'pelias-config' ).generate();
 var recordStream = require('./streams/recordStream');
 var model = require( 'pelias-model' );
 var peliasDbclient = require( 'pelias-dbclient' );


### PR DESCRIPTION
These snuck in somehow. Should we change the maximum number of parameters a function can have before jshint complains? It's currently set to 5. Alternatively we could try to refactor to require fewer parameters.