### PR TITLE
Add npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint": "jshint .",
     "validate": "npm ls",
     "travis": "npm run test && npm run functional",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "start": "node import.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This repo had no NPM start script, which is really useful for making
the interface to all our importers the same.