### PR TITLE
Config imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,8 @@ npm install
 # show full command line options
 node import.js --help
 
-# run a basic import
+# run an import
 node import.js
-
-# run with admin lookup
-node import.js --admin-values
-
-# run with admin lookup and deduplicator
-node import.js --admin-values --deduplicate
 ```
 
 ## Admin Lookup
@@ -70,17 +64,20 @@ hash. A sample configuration file might look like:
 
 ```javascript
 {
-	"imports": {
-		"openaddresses": {
-			"datapath": "/tmp/oa-data",
-			"files": ["us/ny/city_of_new_york.csv"]
-		}
-	}
+  "imports": {
+  "openaddresses": {
+      "adminLookup": true,
+      "deduplicate": false,
+      "datapath": "/tmp/oa-data",
+      "files": ["us/ny/city_of_new_york.csv"]
+    }
+  }
 }
 ```
 
 The following properties are recognized:
-
+  * `adminLookup` : Boolean flag to enable admin lookup (see above).
+  * `deduplicate` : Boolean flag to enable deduplication (see above).
   * `datapath`: The absolute path of the directory containing OpenAddresses files. Must be specified if no directory is
     given as a command-line argument.
   * `files`: An array of the names of the files to import. If specified, *only* these files will be imported, rather

--- a/import.js
+++ b/import.js
@@ -13,6 +13,10 @@ var importPipeline = require( './lib/importPipeline' );
 var adminLookupStream = require('./lib/streams/adminLookupStream');
 var deduplicatorStream = require('./lib/streams/deduplicatorStream');
 
+var wofAdminLookup = require('pelias-wof-admin-lookup');
+var addressDeduplicator = require('pelias-address-deduplicator');
+
+
 // Pretty-print the total time the import took.
 function startTiming() {
   var startTime = new Date().getTime();
@@ -34,8 +38,8 @@ if( 'exitCode' in args ){
 
   var files = parameters.getFileList(peliasConfig, args);
 
-  var deduplicator = deduplicatorStream.create(args.deduplicate);
-  var adminLookup = adminLookupStream.create(args.adminValues, peliasConfig);
+  var deduplicator = deduplicatorStream.create(peliasConfig, addressDeduplicator);
+  var adminLookup = adminLookupStream.create(peliasConfig, wofAdminLookup);
 
   importPipeline.create( files, args.dirPath, deduplicator, adminLookup );
 }

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -41,29 +41,11 @@ function interpretUserArgs( argv, config ){
     '\tOPENADDRESSES_DIR: A directory containing OpenAddresses CSV files.',
     '\t\tIf none is specified, the path from your PELIAS_CONFIG\'s',
     '\t\t`imports.openaddresses.datapath` will be used.',
-    '',
-    '\t--deduplicate: (advanced use) Deduplicate addresses using the',
-    '\t\tOpenVenues deduplicator: https://github.com/openvenues/address_deduper.',
-    '\t\tIt must be running at localhost:5000.',
-    '',
-    '\t--admin-values: (advanced use) OpenAddresses records lack admin values',
-    '\t\t(country, state, city, etc., names), so auto-fill them',
-    '\t\tusing `admin-lookup` See the documentation:',
-    '\t\thttps://github.com/pelias/admin-lookup'
   ].join( '\n' );
 
-  argv = minimist(
-    argv,
-    {
-      boolean: [ 'deduplicate', 'admin-values' ],
-      default: {
-        deduplicate: false,
-        'admin-values': false,
-      }
-    }
-  );
+  argv = minimist(argv, {});
 
-  var validArgs = [ 'deduplicate', 'admin-values', 'help', '_', 'parallel-count', 'parallel-id' ];
+  var validArgs = ['help', '_', 'parallel-count', 'parallel-id' ];
   for( var arg in argv ){
     if( validArgs.indexOf( arg ) === -1 ){
       return {
@@ -78,8 +60,6 @@ function interpretUserArgs( argv, config ){
   }
 
   var opts = {
-    deduplicate: argv.deduplicate,
-    adminValues: argv[ 'admin-values' ],
     'parallel-count': argv['parallel-count'],
     'parallel-id': argv['parallel-id'],
     dirPath: null

--- a/lib/streams/adminLookupStream.js
+++ b/lib/streams/adminLookupStream.js
@@ -1,12 +1,17 @@
 var through = require( 'through2' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
-var peliasAdminLookup = require( 'pelias-wof-admin-lookup' );
 
-function createAdminLookupStream(enable) {
-  if (enable) {
+function createAdminLookupStream(config,adminLookup) {
+  // disable adminLookup with empty config
+  if (!config.imports || !config.imports.openaddresses) {
+    return through.obj(function (doc, enc, next) {
+      next(null, doc);
+    });
+  }
+  if (config.imports.openaddresses.adminLookup) {
     logger.info( 'Setting up admin value lookup stream.' );
-    var pipResolver = peliasAdminLookup.createLocalWofPipResolver();
-    return peliasAdminLookup.createLookupStream(pipResolver);
+    var pipResolver = adminLookup.createLocalWofPipResolver();
+    return adminLookup.createLookupStream(pipResolver);
   } else {
     return through.obj(function (doc, enc, next) {
       next(null, doc);

--- a/lib/streams/deduplicatorStream.js
+++ b/lib/streams/deduplicatorStream.js
@@ -1,11 +1,15 @@
 var through = require( 'through2' );
-var addressDeduplicatorStream = require( 'pelias-address-deduplicator' );
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
 
-function createDeduplicatorStream(enable) {
-  if (enable) {
+function createDeduplicatorStream(config,dedupe) {
+  if (!config.imports || !config.imports.openaddresses) {
+    return through.obj(function (doc, enc, next) {
+      next(null, doc);
+    });
+  }
+  if (config.imports.openaddresses.deduplicate) {
     logger.info( 'Setting up deduplicator.' );
-    return addressDeduplicatorStream();
+    return dedupe();
   } else {
     return through.obj(function (doc, enc, next) {
       next(null, doc);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "pelias-wof-admin-lookup": "2.1.0",
     "through2": "2.0.1",
     "through2-filter": "^2.0.0",
-    "through2-map": "^2.0.0"
+    "through2-map": "^2.0.0",
+    "through2-sink": "^1.0.0"
   },
   "devDependencies": {
     "deep-diff": "^0.3.3",

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -1,5 +1,4 @@
 var tape = require( 'tape' );
-var util = require( 'util' );
 var path = require( 'path' );
 
 var temp = require( 'temp' ).track();
@@ -7,27 +6,15 @@ var temp = require( 'temp' ).track();
 var parameters = require( '../lib/parameters' );
 
 tape( 'interpretUserArgs() correctly handles arguments', function ( test ){
-  var testCases = [
-    [
-      [ '--deduplicate', '--admin-values', 'test'  ],
-      { deduplicate: true, adminValues: true, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined },
-    ],
-    [
-      [ '--admin-values', 'test' ],
-      { deduplicate: false, adminValues: true, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined },
-    ],
-    [
-      [ '--deduplicate', 'test' ],
-      { deduplicate: true, adminValues: false, dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined},
-    ]
+  var testCase = [
+      [ 'test'  ],
+      { dirPath: 'test', 'parallel-count': undefined, 'parallel-id': undefined },
   ];
 
-  testCases.forEach( function execTestCase( testCase, ind ){
-    test.deepEqual(
-      parameters.interpretUserArgs( testCase[ 0 ] ), testCase[ 1 ],
-      util.format( 'Arguments case %d passes.', ind )
-    );
-  });
+  test.deepEqual(
+    parameters.interpretUserArgs( testCase[ 0 ] ), testCase[ 1 ],
+    'Basic arguments case passes.'
+  );
 
   var badArguments = [
     [ 'not an arg', 'some dir' ],

--- a/test/streams/adminLookupStream.js
+++ b/test/streams/adminLookupStream.js
@@ -95,7 +95,7 @@ var wofAdminLookup = {
   tape('disabled: return passthrough stream', function(t) {
     var config = {
     imports: {
-      openstreetmap: {
+      openaddresses: {
         adminLookup: false
       }
     }

--- a/test/streams/adminLookupStream.js
+++ b/test/streams/adminLookupStream.js
@@ -1,0 +1,118 @@
+var sink = require('through2-sink');
+var adminLookup = require('../../lib/streams/adminLookupStream').create;
+var tape = require('tape');
+
+
+tape('enabled: create pipResolver', function (t) {
+    var config = {
+    imports: {
+      openaddresses:{
+        adminLookup: true
+      },
+      adminlookup: {
+        url: 'anything.org'
+      }
+    }
+  };
+
+var wofAdminLookup = {
+    createLocalWofPipResolver: function(){},
+    createLookupStream: function(){}
+  };
+    // assert that the PipResolver was instantiated with the correct URL
+    wofAdminLookup.createLocalWofPipResolver = function () {
+      t.pass('Resolver created');
+      t.end();
+    };
+
+    adminLookup(config, wofAdminLookup);
+  });
+
+tape('enabled: pip resolver is passed into stream constructor', function (t) {
+    var config = {
+    imports: {
+      openaddresses:{
+        adminLookup: true
+      },
+      adminlookup: {
+        url: 'anything.org'
+      }
+    }
+  };
+
+var wofAdminLookup = {
+    createLocalWofPipResolver: function(){},
+    createLookupStream: function(){}
+  };
+
+    t.plan(1); // expect 3 assertions
+
+    var pipResolverMock = {foo: 'bar'};
+
+    // mock the creation of pip resolver
+    wofAdminLookup.createLocalWofPipResolver = function () {
+      return pipResolverMock;
+    };
+
+    wofAdminLookup.createLookupStream = function (pipResolver) {
+      t.equal(pipResolver, pipResolverMock);
+      t.end();
+    };
+
+    adminLookup(config, wofAdminLookup);
+  });
+
+  /*
+   * There was a bug (https://github.com/pelias/wof-admin-lookup/issues/51) where admin lookup could
+   * not be enabled without the adminLookup config section
+   */
+  tape('enabled without any special adminLookup config: return pip stream', function (t) {
+    var config = {
+    imports: {
+      openaddresses: {
+        adminLookup: true
+      }
+    }
+  };
+
+    t.plan(1);
+
+    var streamMock = {madeBy: 'mock'};
+
+    var wofAdminLookup = {
+      createLocalWofPipResolver: function() {
+      },
+      createLookupStream: function() {
+        return streamMock;
+      }
+    };
+
+    var stream = adminLookup(config, wofAdminLookup);
+    t.equal(stream, streamMock, 'stream created');
+    t.end();
+  });
+
+  tape('disabled: return passthrough stream', function(t) {
+    var config = {
+    imports: {
+      openstreetmap: {
+        adminLookup: false
+      }
+    }
+  };
+
+    t.plan(2); // expect 2 assertions
+
+    var dataItem = { some: 'data' };
+
+    var stream = adminLookup(config, {});
+
+    t.equal(typeof stream, 'object', 'disabled stream is an object');
+
+    stream.pipe(sink.obj( function (doc) {
+      t.deepEqual(doc, dataItem);
+      t.end();
+    }));
+
+    stream.write(dataItem);
+  });

--- a/test/streams/deduplicatorStream.js
+++ b/test/streams/deduplicatorStream.js
@@ -1,0 +1,50 @@
+var sink = require('through2-sink');
+var deduper = require('../../lib/streams/deduplicatorStream').create;
+var tape = require('tape');
+
+tape('enabled: return deduper stream',function (t){
+  var config = {
+    imports: {
+      openaddresses: {
+        deduplicate: true
+      }
+    }
+  };
+
+  var deduperStream = { some: 'stream' };
+  var deduperStreamFactory = function () {
+    return deduperStream;
+  };
+
+
+  var stream = deduper(config, deduperStreamFactory);
+  t.equal(stream, deduperStream, 'stream created');
+  t.end();
+
+  });
+
+tape('disabled: return passthrough stream', function(t) {
+    var config = {
+    imports: {
+      opensaddresses: {
+        deduplicate: false
+      }
+    }
+  };
+
+    t.plan(2); // expect 2 assertions
+
+    var dataItem = { some: 'data' };
+
+    var stream = deduper(config, {});
+
+    t.equal(typeof stream, 'object', 'disabled stream is an object');
+
+    stream.pipe(sink.obj( function (doc) {
+      t.deepEqual(doc, dataItem);
+      t.end();
+    }));
+
+    stream.write(dataItem);
+  });
+

--- a/test/streams/deduplicatorStream.js
+++ b/test/streams/deduplicatorStream.js
@@ -26,7 +26,7 @@ tape('enabled: return deduper stream',function (t){
 tape('disabled: return passthrough stream', function(t) {
     var config = {
     imports: {
-      opensaddresses: {
+      openaddresses: {
         deduplicate: false
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,9 @@
 
 require( './parameters' );
 require( './isValidCsvRecord' );
-
+require( './streams/adminLookupStream');
 require( './streams/cleanupStream' );
+require( './streams/deduplicatorStream');
 require( './streams/documentStream' );
 require( './streams/recordStream' );
 require( './streams/isUSorCAHouseNumberZero' );


### PR DESCRIPTION
This should allow the openaddresses importer to, instead of accepting command line arguments, to enable (and disable) admin lookup and deduplication via the config.


Connects pelias/pelias#255
Fixes #51 