### PR TITLE
Use NPM start in parallel script

### DIFF
--- a/bin/parallel
+++ b/bin/parallel
@@ -12,7 +12,7 @@ if [[ $count -ge 1 ]]; then
 
 	# spawn $count parallel builds, passing correct params and all arguments
 	for i in `seq 0 $(($count-1))`; do
-		cmd="node import.js --parallel-count $count --parallel-id $i $@ "
+		cmd="npm start -- --parallel-count $count --parallel-id $i $@ "
 		$cmd &
 	done
 


### PR DESCRIPTION
This small change helps us keep all knowledge of how to run the importer
in one place.