### PR TITLE
Remove trimming regex

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -18,7 +18,7 @@ function createDocumentStream(id_prefix, stats) {
       var model_id = id_prefix + ':' + uid++;
       try {
         var addrDoc = new peliasModel.Document( 'openaddresses', 'address', model_id )
-        .setName( 'default', (record.NUMBER + ' ' + record.STREET).replace(/ +/g, ' ') )
+        .setName( 'default', (record.NUMBER + ' ' + record.STREET) )
         .setCentroid( { lon: record.LON, lat: record.LAT } );
 
         addrDoc.setAddress( 'number', record.NUMBER );


### PR DESCRIPTION
_I found this cleaning out some code sitting on my machine_

This is no longer needed now that we fully trim whitespace in the name
field in [cleanupStream.js](https://github.com/pelias/openaddresses/blob/master/lib/streams/cleanupStream.js#L16-L20).