### PR TITLE
Use OA hash field instead of 

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "node": true,
   "curly": true,
   "eqeqeq": true,

--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const through = require( 'through2' );
 
 const peliasModel = require( 'pelias-model' );

--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -1,6 +1,6 @@
-var through = require( 'through2' );
+const through = require( 'through2' );
 
-var peliasModel = require( 'pelias-model' );
+const peliasModel = require( 'pelias-model' );
 
 /*
  * Create a stream of Documents from valid, cleaned CSV records
@@ -11,13 +11,13 @@ function createDocumentStream(id_prefix, stats) {
    * created by `createRecordStream()`.  See `peliasModel.Document.setId()` for
    * information about UIDs.
    */
-  var uid = 0;
+  let uid = 0;
 
   return through.obj(
     function write( record, enc, next ){
-      var model_id = id_prefix + ':' + uid++;
+      const model_id = id_prefix + ':' + uid++;
       try {
-        var addrDoc = new peliasModel.Document( 'openaddresses', 'address', model_id )
+        const addrDoc = new peliasModel.Document( 'openaddresses', 'address', model_id )
         .setName( 'default', (record.NUMBER + ' ' + record.STREET) )
         .setCentroid( { lon: record.LON, lat: record.LAT } );
 

--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -7,15 +7,18 @@ const peliasModel = require( 'pelias-model' );
  */
 function createDocumentStream(id_prefix, stats) {
   /**
-   * Used to track the UID of individual records passing through the stream
-   * created by `createRecordStream()`.  See `peliasModel.Document.setId()` for
-   * information about UIDs.
+   * Used to track the UID of individual records passing through the stream if
+   * there is no HASH that can be used as a more unique identifier.  See
+   * `peliasModel.Document.setId()` for information about UIDs.
    */
   let uid = 0;
 
   return through.obj(
     function write( record, enc, next ){
-      const model_id = id_prefix + ':' + uid++;
+      const id_number = record.HASH || uid;
+      const model_id = `${id_prefix}:${id_number}`;
+      uid++;
+
       try {
         const addrDoc = new peliasModel.Document( 'openaddresses', 'address', model_id )
         .setName( 'default', (record.NUMBER + ' ' + record.STREET) )

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const tape = require( 'tape' );
 const event_stream = require( 'event-stream' );
 

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -1,21 +1,21 @@
-var tape = require( 'tape' );
-var event_stream = require( 'event-stream' );
+const tape = require( 'tape' );
+const event_stream = require( 'event-stream' );
 
-var DocumentStream = require( '../../lib/streams/documentStream' );
+const DocumentStream = require( '../../lib/streams/documentStream' );
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
+  const input_stream = event_stream.readArray(input);
+  const destination_stream = event_stream.writeArray(callback);
 
   input_stream.pipe(testedStream).pipe(destination_stream);
 }
 
 tape( 'documentStream catches records with no street', function(test) {
-  var input = {
+  const input = {
     NUMBER: 5
   };
-  var stats = { badRecordCount: 0 };
-  var documentStream = DocumentStream.create('prefix', stats);
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
 
   test_stream([input], documentStream, function(err, actual) {
     test.equal(actual.length, 0, 'no documents should be pushed' );
@@ -25,15 +25,15 @@ tape( 'documentStream catches records with no street', function(test) {
 });
 
 tape( 'documentStream does not set zipcode if zipcode is emptystring', function(test) {
-  var input = {
+  const input = {
     NUMBER: '5',
     STREET: '101st Avenue',
     LAT: 5,
     LON: 6,
     POSTCODE: ''
   };
-  var stats = { badRecordCount: 0 };
-  var documentStream = DocumentStream.create('prefix', stats);
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
 
   test_stream([input], documentStream, function(err, actual) {
     test.equal(actual.length, 1, 'the document should be pushed' );
@@ -44,7 +44,7 @@ tape( 'documentStream does not set zipcode if zipcode is emptystring', function(
 });
 
 tape( 'documentStream creates id with filename-based prefix', function(test) {
-  var input = {
+  const input = {
     NUMBER: '5',
     STREET: '101st Avenue',
     LAT: 5,
@@ -52,8 +52,8 @@ tape( 'documentStream creates id with filename-based prefix', function(test) {
     POSTCODE: ''
   };
 
-  var stats = { badRecordCount: 0 };
-  var documentStream = DocumentStream.create('prefix', stats);
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
 
   test_stream([input], documentStream, function(err, actual) {
     test.equal(actual.length, 1, 'the document should be pushed' );

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -62,3 +62,23 @@ tape( 'documentStream creates id with filename-based prefix', function(test) {
     test.end();
   });
 });
+
+tape('documentStream uses HASH value if present', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd'
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.equal(actual[0].getId(), 'prefix:abcd');
+    test.end();
+  });
+});


### PR DESCRIPTION
The OA hash is calculated from the data in each row, so rows with
identical data have identical hashes. This is nice for two reasons:

1.) It means bit-for-bit duplicate records will no longer be inserted
into Elasticsearch multiple times. Instead one document will be updated
several times. This is not quite as efficient as, and is no substitute
for, actually removing duplicate lines from OA files before importing as
a preprocessing step, but it's still nice.

2.) Our current ID scheme simply uses a counter starting at zero, so you
can only find the record if you're sure you have the same file, and want
to count line numbers. The hash will be the same, assuming the data is
the same, even if the file being looked at is newer or older than the
one that was used to import.

**Bonus**
This PR uses const/let which are now available to us in ES6. I chose to use `const` anywhere possible, and only use `let` when the value must change, which is pretty rare. I'm more than happy to discuss other strategies, please bikeshed! :P

Fixes https://github.com/pelias/openaddresses/issues/140
