### PR TITLE
validate config starting at root element, not subelement

### DIFF
--- a/configValidation.js
+++ b/configValidation.js
@@ -8,11 +8,15 @@ const Joi = require('joi');
 // deduplicate: boolean
 // adminLookup: boolean
 const schema = Joi.object().keys({
-  files: Joi.array().items(Joi.string()),
-  datapath: Joi.string(),
-  deduplicate: Joi.boolean(),
-  adminLookup: Joi.boolean()
-}).requiredKeys('datapath').unknown(false);
+  imports: Joi.object().keys({
+    openaddresses: Joi.object().keys({
+      files: Joi.array().items(Joi.string()),
+      datapath: Joi.string(),
+      deduplicate: Joi.boolean(),
+      adminLookup: Joi.boolean()
+    }).requiredKeys('datapath').unknown(false)
+  }).requiredKeys('openaddresses').unknown(true)
+}).requiredKeys('imports').unknown(true);
 
 module.exports = {
   validate: function validate(config) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pelias-dbclient": "2.0.0",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.4.0",
-    "pelias-wof-admin-lookup": "2.8.0",
+    "pelias-wof-admin-lookup": "2.10.0",
     "through2": "^2.0.3",
     "through2-filter": "^2.0.0",
     "through2-map": "^3.0.0",

--- a/test/configValidation.js
+++ b/test/configValidation.js
@@ -4,8 +4,67 @@ const tape = require( 'tape' );
 
 const configValidation = require( '../configValidation' );
 
-tape( 'missing datapath should throw error', function(test) {
+tape('missing imports should throw error', function(test) {
   const config = {};
+
+  test.throws(function() {
+    configValidation.validate(config);
+  }, /"imports" is required/);
+  test.end();
+
+});
+
+tape('non-object imports should throw error', function(test) {
+  [null, 17, 'string', [], true].forEach((value) => {
+    const config = {
+      imports: value
+    };
+
+    test.throws(function() {
+      configValidation.validate(config);
+    }, /"imports" must be an object/);
+  });
+
+  test.end();
+
+});
+
+tape('missing imports.openaddresses should throw error', function(test) {
+  const config = {
+    imports: {
+    }
+  };
+
+  test.throws(function() {
+    configValidation.validate(config);
+  }, /"openaddresses" is required/);
+  test.end();
+
+});
+
+tape('non-object imports.openaddresses should throw error', function(test) {
+  [null, 17, 'string', [], true].forEach((value) => {
+    const config = {
+      imports: {
+        openaddresses: value
+      }
+    };
+
+    test.throws(function() {
+      configValidation.validate(config);
+    }, /"openaddresses" must be an object/);
+  });
+
+  test.end();
+
+});
+
+tape( 'missing datapath should throw error', function(test) {
+  const config = {
+    imports: {
+      openaddresses: {}
+    }
+  };
 
   test.throws(() => {
     configValidation.validate(config);
@@ -17,7 +76,11 @@ tape( 'missing datapath should throw error', function(test) {
 tape( 'non-string datapath should throw error', function(test) {
   [null, 17, {}, [], false].forEach((value) => {
     const config = {
-      datapath: value
+      imports: {
+        openaddresses: {
+          datapath: value
+        }
+      }
     };
 
     test.throws(() => {
@@ -32,13 +95,17 @@ tape( 'non-string datapath should throw error', function(test) {
 tape( 'non-array files should throw error', function(test) {
   [null, 17, {}, 'string', false].forEach((value) => {
     const config = {
-      datapath: 'this is the datapath',
-      files: value
+      imports: {
+        openaddresses: {
+          datapath: 'this is the datapath',
+          files: value
+        }
+      }
     };
 
     test.throws(() => {
       configValidation.validate(config);
-    }, /"files" must be an array/, 'datapath is required');
+    }, /"files" must be an array/);
   });
 
   test.end();
@@ -47,8 +114,12 @@ tape( 'non-array files should throw error', function(test) {
 tape( 'non-string elements in files array should throw error', function(test) {
   [null, 17, {}, [], false].forEach((value) => {
     const config = {
-      datapath: 'this is the datapath',
-      files: [value]
+      imports: {
+        openaddresses: {
+          datapath: 'this is the datapath',
+          files: [value]
+        }
+      }
     };
 
     test.throws(() => {
@@ -62,8 +133,12 @@ tape( 'non-string elements in files array should throw error', function(test) {
 tape( 'non-boolean adminLookup should throw error', function(test) {
   [null, 17, {}, [], 'string'].forEach((value) => {
     const config = {
-      datapath: 'this is the datapath',
-      adminLookup: value
+      imports: {
+        openaddresses: {
+          datapath: 'this is the datapath',
+          adminLookup: value
+        }
+      }
     };
 
     test.throws(() => {
@@ -77,8 +152,12 @@ tape( 'non-boolean adminLookup should throw error', function(test) {
 tape( 'non-boolean deduplicate should throw error', function(test) {
   [null, 17, {}, [], 'string'].forEach((value) => {
     const config = {
-      datapath: 'this is the datapath',
-      deduplicate: value
+      imports: {
+        openaddresses: {
+          datapath: 'this is the datapath',
+          deduplicate: value
+        }
+      }
     };
 
     test.throws(() => {
@@ -91,8 +170,12 @@ tape( 'non-boolean deduplicate should throw error', function(test) {
 
 tape( 'unknown config fields should throw error', function(test) {
   const config = {
-    datapath: 'this is the datapath',
-    unknown: 'value'
+    imports: {
+      openaddresses: {
+        datapath: 'this is the datapath',
+        unknown: 'value'
+      }
+    }
   };
 
   test.throws(() => {
@@ -104,7 +187,11 @@ tape( 'unknown config fields should throw error', function(test) {
 
 tape( 'configuration with only datapath should not throw error', function(test) {
   const config = {
-    datapath: 'this is the datapath'
+    imports: {
+      openaddresses: {
+        datapath: 'this is the datapath'
+      }
+    }
   };
 
   test.doesNotThrow(() => {
@@ -116,10 +203,54 @@ tape( 'configuration with only datapath should not throw error', function(test) 
 
 tape( 'valid configuration should not throw error', function(test) {
   const config = {
-    datapath: 'this is the datapath',
-    deduplicate: false,
-    adminLookup: false,
-    files: ['file 1', 'file 2']
+    imports: {
+      openaddresses: {
+        datapath: 'this is the datapath',
+        deduplicate: false,
+        adminLookup: false,
+        files: ['file 1', 'file 2']
+      }
+    }
+  };
+
+  test.doesNotThrow(() => {
+    configValidation.validate(config);
+  }, 'config should be valid');
+  test.end();
+
+});
+
+tape( 'unknown children of imports should not throw error', function(test) {
+  const config = {
+    imports: {
+      openaddresses: {
+        datapath: 'this is the datapath',
+        deduplicate: false,
+        adminLookup: false,
+        files: ['file 1', 'file 2']
+      },
+      other: {}
+    }
+  };
+
+  test.doesNotThrow(() => {
+    configValidation.validate(config);
+  }, 'config should be valid');
+  test.end();
+
+});
+
+tape( 'unknown children of root should not throw error', function(test) {
+  const config = {
+    imports: {
+      openaddresses: {
+        datapath: 'this is the datapath',
+        deduplicate: false,
+        adminLookup: false,
+        files: ['file 1', 'file 2']
+      }
+    },
+    other: {}
   };
 
   test.doesNotThrow(() => {


### PR DESCRIPTION
`validate` was being called with the root whereas the function itself was working off of the `imports.openaddresses` element.  