### PR TITLE
Increase Node.js memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "validate": "npm ls",
     "travis": "npm run check-dependencies && npm run test && npm run functional",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "start": "node import.js",
+    "start": "node --max_old_space_size=4096 import.js",
     "check-dependencies": "node_modules/.bin/npm-check --production"
   },
   "repository": {


### PR DESCRIPTION
The admin lookup worker processes are starting to hit the default memory
limit. Increasing it gives us time to improve the admin lookup
architecture.

Connected to https://github.com/pelias/wof-admin-lookup/issues/117