### PR TITLE
filter out records with lat/lon both parseable as 0

### DIFF
--- a/lib/isValidCsvRecord.js
+++ b/lib/isValidCsvRecord.js
@@ -6,7 +6,8 @@ var _ = require('lodash');
 function isValidCsvRecord( record ){
   return hasAllProperties(record) &&
           !houseNumberIsExclusionaryWord(record) &&
-          !streetContainsExclusionaryWord(record);
+          !streetContainsExclusionaryWord(record) &&
+          !latLonAreOnNullIsland(record);
 }
 
 /*
@@ -29,6 +30,17 @@ function hasAllProperties(record) {
   return [ 'LON', 'LAT', 'NUMBER', 'STREET' ].every(function(prop) {
     return record[ prop ] && record[ prop ].length > 0;
   });
+}
+
+// returns true when LON and LAT are both parseable as 0
+// > parseFloat('0');
+// 0
+// > parseFloat('0.000000');
+// 0
+// > parseFloat('0.000001');
+// 0.000001
+function latLonAreOnNullIsland(record) {
+  return ['LON', 'LAT'].every(prop => parseFloat(record[prop]) === 0);
 }
 
 module.exports = isValidCsvRecord;

--- a/test/isValidCsvRecord.js
+++ b/test/isValidCsvRecord.js
@@ -128,3 +128,42 @@ tape('street with substring `unavailable` but not on word boundary should return
   test.end();
 
 });
+
+tape('record with lon/lat parseable as 0/0 should return false', test => {
+  const record = {
+    LON: '0.000000',
+    LAT: '0.000000',
+    NUMBER: 'Number',
+    STREET: 'Street'
+  };
+
+  test.notOk( isValidCsvRecord(record), 'should be rejected');
+  test.end();
+
+});
+
+tape('record with lon/lat parseable as 0/non-0 should return true', test => {
+  const record = {
+    LON: '0.000000',
+    LAT: '0.000001',
+    NUMBER: 'Number',
+    STREET: 'Street'
+  };
+
+  test.ok( isValidCsvRecord(record), 'should be accepted');
+  test.end();
+
+});
+
+tape('record with lon/lat parseable as non-0/0 should return true', test => {
+  const record = {
+    LON: '0.000001',
+    LAT: '0.000000',
+    NUMBER: 'Number',
+    STREET: 'Street'
+  };
+
+  test.ok( isValidCsvRecord(record), 'should be accepted');
+  test.end();
+
+});


### PR DESCRIPTION
Fixes #276 and therefore mapzen/leaflet-geocoder#163