### PR TITLE
Use NPX to run Greenkeeper with Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ before_install:
 before_script:
   - npm prune
 after_success:
-  - npm run semantic-release
+  - npm install -g npx
+  - npx -p node@8 npm run semantic-release


### PR DESCRIPTION
Greenkeeper now requires Node.js version 8. Fortunately, `npx` easily lets
us run just Greenkeeper with that Node version.