### PR TITLE
Add a limit to the number of concurrent requests in downloadFiltered

### DIFF
--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -19,7 +19,7 @@ function downloadFiltered(config, callback) {
       return callback(err);
     }
 
-    async.each(files, downloadSource.bind(null, targetDir), callback);
+    async.eachLimit(files, 5, downloadSource.bind(null, targetDir), callback);
 
   });
 


### PR DESCRIPTION
Too many concurrent requests to openaddresses may cause downloads to fail.  
This PR replaces `async.each` with `async.eachLimit` to limit concurrency to 5 parallel requests.