### PR TITLE
Remove very verbose importer log

### DIFF
--- a/lib/streams/cleanupStream.js
+++ b/lib/streams/cleanupStream.js
@@ -1,6 +1,4 @@
-const logger = require('pelias-logger').get('openaddresses');
 const through2 = require( 'through2' );
-const _ = require('lodash');
 
 const cleanup = require( '../cleanup' );
 
@@ -19,12 +17,6 @@ function createCleanupStream() {
         record[key] = record[key].trim();
       }
     });
-
-    // track addresses where the entire housenumber can be reduced to 0
-    const trimmedNumber = _.trimStart(record.NUMBER, '0');
-    if (_.isEmpty(trimmedNumber)) {
-      logger.info('[cleanup_stream] housenumber==0');
-    }
 
     next(null, record);
   });


### PR DESCRIPTION
This line was causing many thousands of log entries to be printed during every import.