### PR TITLE
Download share-alike OA data

### DIFF
--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -22,9 +22,8 @@ function downloadAll(config, callback) {
         // all non-share-alike data
         'https://s3.amazonaws.com/data.openaddresses.io/openaddr-collected-global.zip',
 
-        // leave this out for now since we don't download it in production currently
         // all share-alike data
-        // 'https://s3.amazonaws.com/data.openaddresses.io/openaddr-collected-global-sa.zip'
+        'https://s3.amazonaws.com/data.openaddresses.io/openaddr-collected-global-sa.zip'
       ],
       downloadBundle.bind(null, targetDir),
       callback);


### PR DESCRIPTION
Previously, we would download only the freely distributable OA data,
which is the majority.

It's useful to have all the OA data though.