### PR TITLE
Fully capitalize street directional abbreviations

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -4,16 +4,30 @@ function removeLeadingZerosFromStreet(token) {
   return token.replace(/^(?:0*)([1-9]\d*(st|nd|rd|th))/,'$1');
 }
 
-function capitalizeProperly(streetname){
-  if (streetname.toUpperCase() === streetname || streetname.toLowerCase() === streetname){
-    streetname = _.capitalize(streetname);
+const directionals = ['NE', 'NW', 'SE', 'SW'];
+
+function capitalizeProperly(token){
+  const lowercase = token.toLowerCase();
+  const uppercase = token.toUpperCase();
+
+  // token is a directional, return uppercase variant
+  if (directionals.includes(uppercase)) {
+    return uppercase;
   }
-  return streetname;
+
+  // token is all lowercase or all uppercase, return capitalized variant
+  if (token === lowercase || token === uppercase) {
+    return _.capitalize(token);
+  }
+
+  return token;
 }
 
 function cleanupStreetName(input) {
+  // split streetname into tokens by whitespace
   return input.split(/\s/)
   .map(removeLeadingZerosFromStreet)
+  // remove empty tokens
   .filter(function(part){
     return part.length > 0;
   }).map(capitalizeProperly)

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -84,63 +84,62 @@ tape ( 'cleanupStream trims white space in street field', function(test){
     test.equal(records[0].STREET, '34 West 93rd St');
     test.end();
   });
+});
 
-  tape( 'cleanupStream converts all-caps street names to Title Case', function(test){
-    var inputs = [{
-      NUMBER: '88',
-      STREET: 'GLASGOW STREET'
-    },
-    {
-      NUMBER: '76',
-      STREET : 'McCallister Street' //already capitalized street should be unchanged
-    },
-    {
-      NUMBER: '9923736',
-      STREET: 'Macalester Street'//should also be unchanged
-    },
-    {
-      NUMBER: '314',
-      STREET: 'timid street' //should capitalize first letter of each word
-    },
-    {
-      NUMBER: '4',
-      STREET: 'é'
-    },
-    {
-      NUMBER: '9',
-      STREET: '丁目'
-    }];
-    var expecteds = [{
-      NUMBER: '88',
-      STREET: 'Glasgow Street'
-    },
-    {
-      NUMBER: '76',
-      STREET : 'McCallister Street' //already capitalized street should be unchanged
-    },
-    {
-      NUMBER: '9923736',
-      STREET: 'Macalester Street'//should also be unchanged
-    },
-    {
-      NUMBER: '314',
-      STREET: 'Timid Street' //should capitalize first letter of each word
-    },
-    {
-      NUMBER: '4',
-      STREET: 'É' //should handle non-ASCII characters that can be capitalized
-    },
-    {
-      NUMBER: '9',
-      STREET: '丁目' //should handle non-latin characters
-    }
-    ];
+tape( 'cleanupStream converts all-caps street names to Title Case', function(test){
+  var inputs = [{
+    NUMBER: '88',
+    STREET: 'GLASGOW STREET'
+  },
+  {
+    NUMBER: '76',
+    STREET : 'McCallister Street' //already capitalized street should be unchanged
+  },
+  {
+    NUMBER: '9923736',
+    STREET: 'Macalester Street'//should also be unchanged
+  },
+  {
+    NUMBER: '314',
+    STREET: 'timid street' //should capitalize first letter of each word
+  },
+  {
+    NUMBER: '4',
+    STREET: 'é'
+  },
+  {
+    NUMBER: '9',
+    STREET: '丁目'
+  }];
+  var expecteds = [{
+    NUMBER: '88',
+    STREET: 'Glasgow Street'
+  },
+  {
+    NUMBER: '76',
+    STREET : 'McCallister Street' //already capitalized street should be unchanged
+  },
+  {
+    NUMBER: '9923736',
+    STREET: 'Macalester Street'//should also be unchanged
+  },
+  {
+    NUMBER: '314',
+    STREET: 'Timid Street' //should capitalize first letter of each word
+  },
+  {
+    NUMBER: '4',
+    STREET: 'É' //should handle non-ASCII characters that can be capitalized
+  },
+  {
+    NUMBER: '9',
+    STREET: '丁目' //should handle non-latin characters
+  }];
 
-    var cleanupStream = CleanupStream.create();
+  var cleanupStream = CleanupStream.create();
 
-    test_stream(inputs,cleanupStream,function(err,actual){
-      test.deepEqual(actual, expecteds,'we expect proper capitalization');
-      test.end();
-    });
+  test_stream(inputs,cleanupStream,function(err,actual){
+    test.deepEqual(actual, expecteds,'we expect proper capitalization');
+    test.end();
   });
 });

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -143,3 +143,37 @@ tape( 'cleanupStream converts all-caps street names to Title Case', function(tes
     test.end();
   });
 });
+
+tape( 'cleanupStream converts directionals to uppercase.', function(test){
+  var inputs = [{
+    NUMBER: '88',
+    STREET: 'ne GLASGOW STREET'
+  },
+  {
+    NUMBER: '76',
+    STREET : 'Sw McCallister Street'
+  },
+  {
+    NUMBER: '9923736',
+    STREET: 'Serenity Street'//should be unchanged even though the start matches a directional
+  }];
+  var expecteds = [{
+    NUMBER: '88',
+    STREET: 'NE Glasgow Street'
+  },
+  {
+    NUMBER: '76',
+    STREET : 'SW McCallister Street'
+  },
+  {
+    NUMBER: '9923736',
+    STREET: 'Serenity Street'//should also be unchanged
+  }];
+
+  var cleanupStream = CleanupStream.create();
+
+  test_stream(inputs,cleanupStream,function(err,actual){
+    test.deepEqual(actual, expecteds,'we expect proper capitalization of street directionals');
+    test.end();
+  });
+});


### PR DESCRIPTION
Ensuring proper capitalization has been a challenge for the OA importer for a long time. We made some initial efforts in https://github.com/pelias/openaddresses/pull/131.

This PR expands on the framework that work set up, and ensures street directionals (NW, SW, NE, SE) are always capitalized.

To do some testing, I've created a debug branch of the OA importer that writes just the name field to a file, instead of importing to Elasticsearch. A normal import takes about 2 days, but this branch can process the entire OA dataset in about 10 hours. Using that, we can take a look at the resulting diff output and see if there are any unexpected impacts of this change.

I would love to know if there are common words or abbreviations in any languages that would conflict with this change, but based on my testing I don't believe there is.