### PR TITLE
Show filename of OA download

### DIFF
--- a/test/importPipeline.js
+++ b/test/importPipeline.js
@@ -45,7 +45,7 @@ tape('functional test of importing two small OA files', function(t) {
     var diff = deep(expected, results);
 
     if (diff) {
-      t.fail('expected and actual output are the same');
+      t.fail('expected and actual output are not the same');
       console.log(diff);
     } else {
       t.pass('expected and actual output are the same');

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -4,7 +4,6 @@ const child_process = require('child_process');
 const async = require('async');
 const fs = require('fs-extra');
 const tmp = require('tmp');
-const _ = require('lodash');
 const logger = require('pelias-logger').get('openaddresses-download');
 
 function downloadFiltered(config, callback) {
@@ -28,9 +27,10 @@ function downloadFiltered(config, callback) {
 function downloadSource(targetDir, file, callback) {
   logger.info(`Downloading ${file}`);
 
-  const source = _.replace(file, '.csv', '.zip');
+  const source = file.replace('.csv', '.zip');
+  const name = file.replace('.csv', '').replace(/\//g,'-');
   const sourceUrl = `https://results.openaddresses.io/latest/run/${source}`;
-  const tmpZipFile = tmp.tmpNameSync({postfix: '.zip'});
+  const tmpZipFile = tmp.tmpNameSync({prefix: name, postfix: '.zip'});
 
   async.series(
     [

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -5,7 +5,7 @@ const async = require('async');
 const fs = require('fs-extra');
 const tmp = require('tmp');
 const _ = require('lodash');
-const logger = require('pelias-logger').get('download');
+const logger = require('pelias-logger').get('openaddresses-download');
 
 function downloadFiltered(config, callback) {
   const targetDir = config.imports.openaddresses.datapath;


### PR DESCRIPTION
When downloading OA data, each file is written to a temporary file with a completely random name. This makes debugging failed downloads difficult.

This PR changes the filename to include the OA source, so bad files can be tracked down.