### PR TITLE
feat(test): Use dedicated test script to catch errors

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -euo pipefail
+
+node test/test.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "import": "npm start",
     "parallel": "./bin/parallel",
     "test": "NODE_ENV=test npm run units",
-    "units": "node test/test.js | tap-spec",
+    "units": "./bin/units",
     "functional": "NODE_ENV=test node test/functional.js | tap-spec",
     "lint": "jshint .",
     "validate": "npm ls",


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail` option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744