### PR TITLE
fix(parallel-import): pass all parameters in start script

### DIFF
--- a/bin/parallel
+++ b/bin/parallel
@@ -12,7 +12,7 @@ if [[ $count -ge 1 ]]; then
 
 	# spawn $count parallel builds, passing correct params and all arguments
 	for i in `seq 0 $(($count-1))`; do
-		cmd="npm start -- --parallel-count $count --parallel-id $i $@ "
+		cmd="./bin/start --parallel-count $count --parallel-id $i $@ "
 		$cmd &
 	done
 

--- a/bin/parallel
+++ b/bin/parallel
@@ -12,7 +12,7 @@ if [[ $count -ge 1 ]]; then
 
 	# spawn $count parallel builds, passing correct params and all arguments
 	for i in `seq 0 $(($count-1))`; do
-		cmd="./bin/start --parallel-count $count --parallel-id $i $@ "
+		cmd="./bin/start --parallel-count $count --parallel-id $i $@"
 		$cmd &
 	done
 

--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec node --max_old_space_size=4096 import.js
+exec node --max_old_space_size=4096 import.js $@


### PR DESCRIPTION
The parallel import functionality requires parameters to be passed. The start script was not doing this.