### PR TITLE
feat(import): add missingFilesAreFatal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following configuration options are supported by this importer.
 | --- | --- | --- | --- |
 | `datapath` | yes | | The absolute path of the directory containing OpenAddresses files. Must be specified if no directory is given as a command-line argument. |
 | `files` | no | | An array of the names of the files to download/import. If specified, *only* these files will be downloaded and imported, rather than *all* `.csv` files in the given directory. **If the array is empty, all files will be downloaded and imported.** Refer to the [OpenAddresses data listing]( http://results.openaddresses.io/?runs=all#runs) for file names.|
+| `missingFilesAreFatal` | no | false | If set to true, any missing files will immediately halt the importer with an error. Otherwise, the importer will continue processing with a warning |
 
 ## Parallel Importing
 

--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -6,6 +6,8 @@ var combinedStream = require( 'combined-stream' );
 var _ = require( 'lodash' );
 
 var logger = require( 'pelias-logger' ).get( 'openaddresses' );
+const config = require('pelias-config').generate();
+
 var CleanupStream = require('./cleanupStream');
 var ValidRecordFilterStream = require('./validRecordFilterStream');
 var DocumentStream = require('./documentStream');
@@ -80,6 +82,16 @@ function createFullRecordStream(files, dirPath) {
   var recordStream = combinedStream.create();
 
   files.forEach( function forEach( filePath ){
+    if (!fs.existsSync(filePath)) {
+      if (config.get('imports.openaddresses.missingFilesAreFatal')) {
+        logger.error(`File ${filePath} not found, quitting`);
+        process.exit(1);
+      } else {
+        logger.warn(`File ${filePath} not found, skipping`);
+        return;
+      }
+    }
+
     recordStream.append( function ( next ){
       logger.info( 'Creating read stream for: ' + filePath );
       next(createRecordStream( filePath, dirPath ) );

--- a/schema.js
+++ b/schema.js
@@ -11,7 +11,8 @@ module.exports = Joi.object().keys({
     openaddresses: Joi.object().keys({
       files: Joi.array().items(Joi.string()),
       datapath: Joi.string(),
-      adminLookup: Joi.boolean()
+      adminLookup: Joi.boolean(),
+      missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true)
     }).requiredKeys('datapath').unknown(false)
   }).requiredKeys('openaddresses').unknown(true)
 }).requiredKeys('imports').unknown(true);


### PR DESCRIPTION
This adds a config option similar to the one in the [Who's on First importer](https://github.com/pelias/whosonfirst#configuration), which will allow users of this importer to decide if a missing file should count as a fatal error or be skipped gracefully.

Previously, this importer would import files until it got to one that doesn't exist, and then exit with an unclear error.

Now, the importer either quits right away (if `missingFilesAreFatal` is true), or emits a warning message and continues with the other files. Gracefully skipping missing files is now the default.

Fixes https://github.com/pelias/openaddresses/issues/311