### PR TITLE
Use new dbclient name functionality

### DIFF
--- a/import.js
+++ b/import.js
@@ -43,5 +43,12 @@ if( 'exitCode' in args ){
 
   var files = parameters.getFileList(peliasConfig, args);
 
-  importPipeline.create( files, args.dirPath, adminLookupStream.create(adminLayers) );
+  const importer_id = args['parallel-id'];
+  let importer_name = 'openstreetmap';
+
+  if (importer_id !== undefined) {
+    importer_name = `openstreetmap-${importer_id}`;
+  }
+
+  importPipeline.create( files, args.dirPath, adminLookupStream.create(adminLayers), importer_name);
 }

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -16,17 +16,15 @@ const isUSorCAHouseNumberZero = require('./streams/isUSorCAHouseNumberZero');
  *        OpenAddresses doesn't contain any) using `admin-lookup`. See the
  *        documentation: https://github.com/pelias/admin-lookup
  */
-function createFullImportPipeline( files, dirPath, adminLookupStream, finalStream ){ // jshint ignore:line
+function createFullImportPipeline( files, dirPath, adminLookupStream ){ // jshint ignore:line
   logger.info( 'Importing %s files.', files.length );
-
-  finalStream = finalStream || peliasDbclient();
 
   recordStream.create(files, dirPath)
     .pipe(blacklistStream())
     .pipe(adminLookupStream)
     .pipe(isUSorCAHouseNumberZero.create())
     .pipe(model.createDocumentMapperStream())
-    .pipe(finalStream);
+    .pipe(peliasDbclient());
 }
 
 module.exports = {

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -16,7 +16,7 @@ const isUSorCAHouseNumberZero = require('./streams/isUSorCAHouseNumberZero');
  *        OpenAddresses doesn't contain any) using `admin-lookup`. See the
  *        documentation: https://github.com/pelias/admin-lookup
  */
-function createFullImportPipeline( files, dirPath, adminLookupStream ){ // jshint ignore:line
+function createFullImportPipeline( files, dirPath, adminLookupStream, importerName ){ // jshint ignore:line
   logger.info( 'Importing %s files.', files.length );
 
   recordStream.create(files, dirPath)
@@ -24,7 +24,7 @@ function createFullImportPipeline( files, dirPath, adminLookupStream ){ // jshin
     .pipe(adminLookupStream)
     .pipe(isUSorCAHouseNumberZero.create())
     .pipe(model.createDocumentMapperStream())
-    .pipe(peliasDbclient());
+    .pipe(peliasDbclient({name: importerName}));
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^3.3.0",
-    "pelias-dbclient": "^2.5.6",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^5.5.2",
     "pelias-wof-admin-lookup": "^5.0.0",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which
importer during an import.

Unlike other importers, this PR is slightly more complicated as we have
to support unique names for each of what might be several parallel
sub-importers.

Dependency injection for `dbclient` was removed in favor of using
`proxyquire` for testing to facilitate this.

Connects pelias/dbclient#101