### PR TITLE
fix(download): Respect `missingFilesAreFatal` parameter

### DIFF
--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -1,6 +1,5 @@
-'use strict';
-
 const child_process = require('child_process');
+const config = require( 'pelias-config' ).generate();
 const async = require('async');
 const fs = require('fs-extra');
 const tmp = require('tmp');
@@ -24,7 +23,7 @@ function downloadFiltered(config, callback) {
 
 }
 
-function downloadSource(targetDir, file, callback) {
+function downloadSource(targetDir, file, main_callback) {
   logger.info(`Downloading ${file}`);
 
   const source = file.replace('.csv', '.zip');
@@ -47,7 +46,14 @@ function downloadSource(targetDir, file, callback) {
       // delete the temp downloaded zip file
       fs.remove.bind(null, tmpZipFile)
     ],
-    callback);
+    function(err) {
+      if (err) {
+          logger.warn(`failed to download ${sourceUrl}: ${err}`);
+      }
+
+      const errorsFatal = config.get('imports.openaddresses.missingFilesAreFatal');
+      main_callback(errorsFatal ? err : null);
+    });
 }
 
 module.exports = downloadFiltered;


### PR DESCRIPTION
The OpenAddresses download did not include error handling that took the `missingFilesAreFatal` parameter into account. Therefore, all download errors stopped the entire download process.

Especially for large areas that include many of the individual OA files, gracefully skipping files that have download errors can be a convenient way to handle sources that are having issues.

Fixes https://github.com/pelias/openaddresses/issues/425