### PR TITLE
tests(streams) move away from event-stream, replace with stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "deep-diff": "^1.0.0",
-    "event-stream": "^4.0.0",
+    "stream-mock": "^2.0.3",
     "jshint": "^2.9.4",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",

--- a/test/importPipeline.js
+++ b/test/importPipeline.js
@@ -2,23 +2,40 @@ var fs = require( 'fs' );
 var path = require( 'path');
 
 var tape = require( 'tape' );
-var event_stream = require( 'event-stream' );
 var deep = require( 'deep-diff' );
 var map = require('through2-map');
 var _ = require('lodash');
 var proxyquire = require('proxyquire');
-
+const stream = require('stream');
 
 var basePath = path.resolve(__dirname);
 var expectedPath = basePath + '/data/expected.json';
 var inputFiles =  [ basePath + '/data/input_file_1.csv', basePath + '/data/input_file_2.csv'];
+
+function writableStreamArray(cb) {
+
+  const s = new stream.Stream();
+  let arr = [];
+  let streamFinished = false;
+
+  s.end = function() {
+    streamFinished = true;
+    cb(null, arr);
+  };
+
+  s.write = function (ele) {
+    arr.push(ele);
+  };
+
+  return s;
+}
 
 tape('functional test of importing two small OA files', function(t) {
   var expected = JSON.parse(fs.readFileSync(expectedPath));
 
   // return a stream that does the actual test
   function fakeDbclient() {
-    return event_stream.writeArray(function(err, results) {
+    return writableStreamArray(function(err, results) {
       // uncomment this to write the actual results to the expected file
       // make sure they look ok though. comma left off so jshint reminds you
       // not to commit this line

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -1,13 +1,15 @@
 var tape = require( 'tape' );
-var event_stream = require( 'event-stream' );
 
 var CleanupStream = require( '../../lib/streams/cleanupStream' );
 
-function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-  input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'cleanupStream trims whitespace from all fields', function(test) {

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -1,15 +1,17 @@
 'use strict';
 
 const tape = require( 'tape' );
-const event_stream = require( 'event-stream' );
+
+const stream_mock = require('stream-mock');
 
 const DocumentStream = require( '../../lib/streams/documentStream' );
 
 function test_stream(input, testedStream, callback) {
-  const input_stream = event_stream.readArray(input);
-  const destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'documentStream catches records with no street', function(test) {

--- a/test/streams/germanicAbbreviationStream.js
+++ b/test/streams/germanicAbbreviationStream.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require( 'event-stream' );
+const stream_mock = require('stream-mock');
 
 var germanicStream = require( '../../lib/streams/germanicAbbreviationStream' );
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'germanicStream expands tokens ending in "-str." to "-strasse" (mostly DEU)', function(test) {

--- a/test/streams/isUSorCAHouseNumberZero.js
+++ b/test/streams/isUSorCAHouseNumberZero.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
-
 var isUSorCAHouseNumberZero = require('../../lib/streams/isUSorCAHouseNumberZero');
 
-function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-    input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('isUSorCAHouseNumberZero', function(t) {


### PR DESCRIPTION
Replacing event-stream with stream-mock as discussed in pelias/pelias#801