### PR TITLE
download openaddresses "global" files via cloudflare CDN

### DIFF
--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -20,10 +20,10 @@ function downloadAll(config, callback) {
     async.each(
       [
         // all non-share-alike data
-        'https://s3.amazonaws.com/data.openaddresses.io/openaddr-collected-global.zip',
+        'https://data.openaddresses.io/openaddr-collected-global.zip',
 
         // all share-alike data
-        'https://s3.amazonaws.com/data.openaddresses.io/openaddr-collected-global-sa.zip'
+        'https://data.openaddresses.io/openaddr-collected-global-sa.zip'
       ],
       downloadBundle.bind(null, targetDir),
       callback);


### PR DESCRIPTION
The OA project can incur significant costs when many users download directly from S3.
This PR changes the URL used for 'global' downloads to point to their Cloudflare CDN.