### PR TITLE
Rate limiting, using bottleneck

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fs-extra": "^7.0.0",
     "glob": "^7.0.0",
     "joi": "^14.0.0",
+    "limited-request-queue": "^5.0.0",
     "lodash": "^4.16.0",
     "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "main": "import.js",
   "dependencies": {
     "async": "^2.5.0",
+    "bottleneck": "^2.19.5",
     "combined-stream": "^1.0.7",
     "csv-parse": "^4.0.0",
     "fs-extra": "^7.0.0",
     "glob": "^7.0.0",
     "joi": "^14.0.0",
-    "limited-request-queue": "^5.0.0",
     "lodash": "^4.16.0",
     "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -19,9 +19,11 @@ function downloadFiltered(config, callback) {
     logger.info(`Attempting to download selected data files: ${files.map(file => file.csv)}`);
 
     // limit requests to avoid being banned by openaddresses.io
+    // current policy is 10 request per minute
+    // https://github.com/pelias/openaddresses/issues/433#issuecomment-527383976
     const options = {
       maxConcurrent: 1,
-      minTime: 3000
+      minTime: 6000
     };
     const limiter = new Bottleneck(options);
     const callbackOnLastOne = () => {

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -23,10 +23,14 @@ function downloadFiltered(config, callback) {
       maxConcurrent: 1,
       minTime: 3000
     };
-    const limiter = new Bottleneck(options)
-      .on('empty', callback); // This will be called when `limiter.empty()` becomes true.
+    const limiter = new Bottleneck(options);
+    const callbackOnLastOne = () => {
+      if (limiter.empty()) {
+        callback();
+      }
+    };
     files.map(file => {
-      limiter.submit(downloadSource, targetDir, file, null);
+      limiter.submit(downloadSource, targetDir, file, callbackOnLastOne);
     });
     process.on('SIGINT', () => {
       limiter.stop({dropWaitingJobs: true});

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -4,12 +4,11 @@ const async = require('async');
 const fs = require('fs-extra');
 const tmp = require('tmp');
 const logger = require('pelias-logger').get('openaddresses-download');
+const RequestQueue = require('limited-request-queue');
+const URL = require('url').URL;
 
 function downloadFiltered(config, callback) {
   const targetDir = config.imports.openaddresses.datapath;
-  const files = config.imports.openaddresses.files;
-
-  logger.info(`Attempting to download selected data files: ${files}`);
 
   fs.ensureDir(targetDir, (err) => {
     if (err) {
@@ -17,49 +16,72 @@ function downloadFiltered(config, callback) {
       return callback(err);
     }
 
-    async.eachLimit(files, 5, downloadSource.bind(null, targetDir), callback);
+    const files = getFiles(config, targetDir, callback);
+    logger.info(`Attempting to download selected data files: ${files.map(file => file.csv)}`);
 
+    // wait to avoid being banned by openaddresses.io
+    const options = {
+      maxSockets: 1,
+      rateLimit: 3000
+    };
+    const queue = new RequestQueue.default(options)
+      .on(RequestQueue.ITEM_EVENT, (url, data, done) => {
+        downloadSource(targetDir, data.file, () => done());
+      })
+      .on(RequestQueue.END_EVENT, callback);
+    files.map(file => {
+      queue.enqueue(new URL(file.url), {file: file});
+    });
   });
 
 }
 
+function getFiles(config, targetDir, main_callback){
+  const errorsFatal = config.get('imports.openaddresses.missingFilesAreFatal');
+  const files = config.imports.openaddresses.files;
+  files.forEach(file => {
+    // sources MUST end with '.csv'
+    if( !file.endsWith('.csv') ){
+      const msg = `invalid source '${file}': MUST end with '.csv'`;
+      logger.warn(msg);
+
+      // respect 'imports.openaddresses.missingFilesAreFatal' setting
+      return main_callback(errorsFatal ? msg : null);
+    }
+  });
+  return files.map(file => {
+    const source = file.replace('.csv', '.zip');
+    const name = file.replace('.csv', '').replace(/\//g,'-');
+    return {
+      csv: file,
+      url: `https://results.openaddresses.io/latest/run/${source}`,
+      zip: tmp.tmpNameSync({prefix: name, dir: targetDir, postfix: '.zip'})
+    };
+  });
+}
+
 function downloadSource(targetDir, file, main_callback) {
   const errorsFatal = config.get('imports.openaddresses.missingFilesAreFatal');
-  logger.info(`Downloading ${file}`);
-
-  const source = file.replace('.csv', '.zip');
-  const sourceUrl = `https://results.openaddresses.io/latest/run/${source}`;
-
-  // sources MUST end with '.csv'
-  if( !file.endsWith('.csv') ){
-    const msg = `invalid source '${file}': MUST end with '.csv'`;
-    logger.warn(msg);
-
-    // respect 'imports.openaddresses.missingFilesAreFatal' setting
-    return main_callback(errorsFatal ? msg : null);
-  }
-
-  const name = file.replace('.csv', '').replace(/\//g,'-');
-  const tmpZipFile = tmp.tmpNameSync({prefix: name, dir: targetDir, postfix: '.zip'});
+  logger.info(`Downloading ${file.csv}`);
 
   async.series(
     [
       // download the zip file into the temp directory
       (callback) => {
-        logger.debug(`downloading ${sourceUrl}`);
-        child_process.exec(`curl -L -X GET -o ${tmpZipFile} ${sourceUrl}`, callback);
+        logger.debug(`downloading ${file.url}`);
+        child_process.exec(`curl -L -X GET -o ${file.zip} ${file.url}`, callback);
       },
       // unzip file into target directory
       (callback) => {
-        logger.debug(`unzipping ${tmpZipFile} to ${targetDir}`);
-        child_process.exec(`unzip -o -qq -d ${targetDir} ${tmpZipFile}`, callback);
+        logger.debug(`unzipping ${file.zip} to ${targetDir}`);
+        child_process.exec(`unzip -o -qq -d ${targetDir} ${file.zip}`, callback);
       },
       // delete the temp downloaded zip file
-      fs.remove.bind(null, tmpZipFile)
+      fs.remove.bind(null, file.zip)
     ],
     function(err) {
       if (err) {
-          logger.warn(`failed to download ${sourceUrl}: ${err}`);
+          logger.warn(`failed to download ${file.url}: ${err}`);
       }
 
       // honour 'imports.openaddresses.missingFilesAreFatal' setting

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -28,6 +28,10 @@ function downloadFiltered(config, callback) {
     files.map(file => {
       limiter.submit(downloadSource, targetDir, file, null);
     });
+    process.on('SIGINT', () => {
+      limiter.stop({dropWaitingJobs: true});
+      process.exit();
+    });
   });
 
 }


### PR DESCRIPTION
Replaces #434, to fix #433.

Implements:
- limit the rate of HTTP requests to OpenAddresses to 10 per minute. See https://github.com/pelias/openaddresses/issues/433#issuecomment-527383976
- interruption on Ctrl+C