### PR TITLE
Allow configuring download location

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ If set to true, any missing files will immediately halt the importer with an
 error. Otherwise, the importer will continue processing with a warning. The
 data downloader will also continue if any download errors were encountered with this set to false.
 
+### `imports.openaddresses.dataHost`
+
+* Required: no
+* Default: `https://data.openaddresses.io`
+
+The location from which to download OpenAddresses data from. By default, the
+primary OpenAddresses servers will be used. This can be overrriden to allow
+downloading customized data. Paths are supported (for example,
+`https://yourhost.com/path/to/your/data`), but must not end with a trailing
+slash.
+
 ## Parallel Importing
 
 Because OpenAddresses consists of many small files, this importer can be configured to run several instances in parallel that coordinate to import all the data.

--- a/schema.js
+++ b/schema.js
@@ -9,6 +9,7 @@ module.exports = Joi.object().keys({
     openaddresses: Joi.object().keys({
       files: Joi.array().items(Joi.string()),
       datapath: Joi.string(),
+      dataHost: Joi.string(),
       adminLookup: Joi.boolean(),
       missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no').insensitive(true)
     }).requiredKeys('datapath').unknown(false)

--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -15,13 +15,15 @@ function downloadAll(config, callback) {
       return callback(err);
     }
 
+    const dataHost = config.get('imports.openaddresses.dataHost') || 'https://data.openaddresses.io';
+
     async.each(
       [
         // all non-share-alike data
-        'https://data.openaddresses.io/openaddr-collected-global.zip',
+        `${dataHost}/openaddr-collected-global.zip`,
 
         // all share-alike data
-        'https://data.openaddresses.io/openaddr-collected-global-sa.zip'
+        `${dataHost}/openaddr-collected-global-sa.zip`
       ],
       downloadBundle.bind(null, targetDir),
       callback);


### PR DESCRIPTION
This allows specifying a custom location to download OpenAddresses data from, which can be useful for a variety of reasons.

cc @Joxit :)