### PR TITLE
generate semi-permanent content hashes for OA rows

### DIFF
--- a/lib/streams/contentHashStream.js
+++ b/lib/streams/contentHashStream.js
@@ -1,0 +1,41 @@
+const _ = require('lodash');
+const crypto = require('crypto');
+const through2 = require('through2');
+
+/*
+ * create a stream that generates a content-hash for each row
+ */
+
+function createContentHashStream() {
+  return through2.obj(function (record, enc, next) {
+    record.HASH = hash(record);
+    next(null, record);
+  });
+}
+
+function hash( record ) {
+  // md5 is actually 512 bits, we only need 256 bits to match the 16x hex char
+  // uuid4 implementation used by the openaddresses project, so half are discarded.
+  // it was chosen due to its universal availability and maturity.
+  // note: this algo need not be cryptographically secure, it's just more
+  // convenient and reliable to use this method than using other methods.
+  const h = crypto.createHash('md5');
+
+  // iterate over object properties, adding them to the content-hash
+  if( _.isObject( record ) ){
+    _.map( record, (v, k) => {
+      const key = k.toString().trim().toLowerCase();
+      const val = v.toString().trim().toLowerCase();
+      if (key === 'hash') { return; } // ignore any existing hash property
+      h.update(`${key}:${val}`);
+    });
+  }
+
+  // return a hexidecimal representation
+  return h.digest('hex').substr(0, 16);
+}
+
+module.exports = {
+  create: createContentHashStream,
+  hash: hash
+};

--- a/lib/streams/contentHashStream.js
+++ b/lib/streams/contentHashStream.js
@@ -7,11 +7,24 @@ const through2 = require('through2');
  */
 
 function createContentHashStream() {
-  return through2.obj(function (record, enc, next) {
+  return through2.obj((record, enc, next) => {
     record.HASH = hash(record);
     next(null, record);
   });
 }
+
+const normalize = {
+  float: (fl) => (Math.floor(parseFloat(fl||0.0)*1e7)/1e7).toFixed(7),
+  string: (str) => (str||'').toString().replace(/\s+/g, ' ').trim().toLowerCase()
+};
+
+const fields = [
+  { key: 'LON', norm: normalize.float },
+  { key: 'LAT', norm: normalize.float },
+  { key: 'STREET', norm: normalize.string },
+  { key: 'NUMBER', norm: normalize.string },
+  { key: 'UNIT', norm: normalize.string }
+];
 
 function hash( record ) {
   // md5 is actually 512 bits, we only need 256 bits to match the 16x hex char
@@ -21,15 +34,16 @@ function hash( record ) {
   // convenient and reliable to use this method than using other methods.
   const h = crypto.createHash('md5');
 
-  // iterate over object properties, adding them to the content-hash
-  if( _.isObject( record ) ){
-    _.map( record, (v, k) => {
-      const key = k.toString().trim().toLowerCase();
-      const val = v.toString().trim().toLowerCase();
-      if (key === 'hash') { return; } // ignore any existing hash property
-      h.update(`${key}:${val}`);
-    });
-  }
+  // see: https://github.com/pelias/openaddresses/pull/442#issuecomment-535399779
+  fields.forEach( field => {
+    // write a null byte in place of an empty value
+    // in order to preserve column positions.
+    let str = '\0';
+    if (_.has(record, field.key)) {
+      str = field.norm(_.get(record, field.key));
+    }
+    h.update(str);
+  });
 
   // return a hexidecimal representation
   return h.digest('hex').substr(0, 16);

--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -1,16 +1,17 @@
-var fs = require( 'fs' );
-var path = require( 'path' );
+const fs = require( 'fs' );
+const path = require( 'path' );
 
-var csvParse = require( 'csv-parse' );
-var combinedStream = require( 'combined-stream' );
-var _ = require( 'lodash' );
+const csvParse = require( 'csv-parse' );
+const combinedStream = require( 'combined-stream' );
+const _ = require( 'lodash' );
 
-var logger = require( 'pelias-logger' ).get( 'openaddresses' );
+const logger = require( 'pelias-logger' ).get( 'openaddresses' );
 const config = require('pelias-config').generate();
 
-var CleanupStream = require('./cleanupStream');
-var ValidRecordFilterStream = require('./validRecordFilterStream');
-var DocumentStream = require('./documentStream');
+const CleanupStream = require('./cleanupStream');
+const ContentHashStream = require('./contentHashStream');
+const ValidRecordFilterStream = require('./validRecordFilterStream');
+const DocumentStream = require('./documentStream');
 
 /*
  * Construct a suitable id prefix for a CSV file given
@@ -50,7 +51,7 @@ function createRecordStream( filePath, dirPath ){
     logger.verbose( 'Number of bad records: ' + stats.badRecordCount );
   }, 10000 );
 
-  var csvParser = csvParse({
+  const csvParser = csvParse({
     trim: true,
     skip_empty_lines: true,
     relax_column_count: true,
@@ -58,10 +59,11 @@ function createRecordStream( filePath, dirPath ){
     columns: true
   });
 
-  var validRecordFilterStream = ValidRecordFilterStream.create();
-  var cleanupStream = CleanupStream.create();
-  var idPrefix = getIdPrefix(filePath, dirPath);
-  var documentStream = DocumentStream.create(idPrefix, stats);
+  const contentHashStream = ContentHashStream.create();
+  const validRecordFilterStream = ValidRecordFilterStream.create();
+  const cleanupStream = CleanupStream.create();
+  const idPrefix = getIdPrefix(filePath, dirPath);
+  const documentStream = DocumentStream.create(idPrefix, stats);
 
   documentStream._flush = function end( done ){
     clearInterval( intervalId );
@@ -70,6 +72,7 @@ function createRecordStream( filePath, dirPath ){
 
   return fs.createReadStream( filePath )
     .pipe( csvParser )
+    .pipe( contentHashStream )
     .pipe( validRecordFilterStream )
     .pipe( cleanupStream )
     .pipe( documentStream );

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -1,7 +1,7 @@
 [
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:0",
+    "_id": "openaddresses:address:data/input_file_1:30ffa79e5dc1a56d",
     "_type": "doc",
     "data": {
       "name": {
@@ -104,12 +104,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:0"
+      "source_id": "data/input_file_1:30ffa79e5dc1a56d"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:1",
+    "_id": "openaddresses:address:data/input_file_1:bbf7eee6b93e0a98",
     "_type": "doc",
     "data": {
       "name": {
@@ -128,12 +128,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:1"
+      "source_id": "data/input_file_1:bbf7eee6b93e0a98"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:2",
+    "_id": "openaddresses:address:data/input_file_1:2376569de5cd9453",
     "_type": "doc",
     "data": {
       "name": {
@@ -152,12 +152,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:2"
+      "source_id": "data/input_file_1:2376569de5cd9453"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:3",
+    "_id": "openaddresses:address:data/input_file_1:1b2747d60708b5da",
     "_type": "doc",
     "data": {
       "name": {
@@ -176,12 +176,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:3"
+      "source_id": "data/input_file_1:1b2747d60708b5da"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:4",
+    "_id": "openaddresses:address:data/input_file_1:f3434edf57eff004",
     "_type": "doc",
     "data": {
       "name": {
@@ -200,12 +200,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:4"
+      "source_id": "data/input_file_1:f3434edf57eff004"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:0",
+    "_id": "openaddresses:address:data/input_file_2:0d9f51f5926d3373",
     "_type": "doc",
     "data": {
       "name": {
@@ -224,12 +224,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:0"
+      "source_id": "data/input_file_2:0d9f51f5926d3373"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:1",
+    "_id": "openaddresses:address:data/input_file_2:1f21520c9f4df36f",
     "_type": "doc",
     "data": {
       "name": {
@@ -248,12 +248,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:1"
+      "source_id": "data/input_file_2:1f21520c9f4df36f"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:2",
+    "_id": "openaddresses:address:data/input_file_2:b87805454ead82d0",
     "_type": "doc",
     "data": {
       "name": {
@@ -272,12 +272,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:2"
+      "source_id": "data/input_file_2:b87805454ead82d0"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:3",
+    "_id": "openaddresses:address:data/input_file_2:eba176e31fdf30d7",
     "_type": "doc",
     "data": {
       "name": {
@@ -296,7 +296,7 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:3"
+      "source_id": "data/input_file_2:eba176e31fdf30d7"
     }
   }
 ]

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -1,7 +1,7 @@
 [
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:30ffa79e5dc1a56d",
+    "_id": "openaddresses:address:data/input_file_1:7552fdd1d9eb5765",
     "_type": "doc",
     "data": {
       "name": {
@@ -104,12 +104,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:30ffa79e5dc1a56d"
+      "source_id": "data/input_file_1:7552fdd1d9eb5765"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:bbf7eee6b93e0a98",
+    "_id": "openaddresses:address:data/input_file_1:e21716b47966b98a",
     "_type": "doc",
     "data": {
       "name": {
@@ -128,12 +128,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:bbf7eee6b93e0a98"
+      "source_id": "data/input_file_1:e21716b47966b98a"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:2376569de5cd9453",
+    "_id": "openaddresses:address:data/input_file_1:7456321cc7d6d352",
     "_type": "doc",
     "data": {
       "name": {
@@ -152,12 +152,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:2376569de5cd9453"
+      "source_id": "data/input_file_1:7456321cc7d6d352"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:1b2747d60708b5da",
+    "_id": "openaddresses:address:data/input_file_1:f026cd5494a7e4f4",
     "_type": "doc",
     "data": {
       "name": {
@@ -176,12 +176,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:1b2747d60708b5da"
+      "source_id": "data/input_file_1:f026cd5494a7e4f4"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_1:f3434edf57eff004",
+    "_id": "openaddresses:address:data/input_file_1:4509c0194f1efaca",
     "_type": "doc",
     "data": {
       "name": {
@@ -200,12 +200,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_1:f3434edf57eff004"
+      "source_id": "data/input_file_1:4509c0194f1efaca"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:0d9f51f5926d3373",
+    "_id": "openaddresses:address:data/input_file_2:fc6d8b0a0e5cda70",
     "_type": "doc",
     "data": {
       "name": {
@@ -224,12 +224,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:0d9f51f5926d3373"
+      "source_id": "data/input_file_2:fc6d8b0a0e5cda70"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:1f21520c9f4df36f",
+    "_id": "openaddresses:address:data/input_file_2:b7c25b5e6eea7831",
     "_type": "doc",
     "data": {
       "name": {
@@ -248,12 +248,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:1f21520c9f4df36f"
+      "source_id": "data/input_file_2:b7c25b5e6eea7831"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:b87805454ead82d0",
+    "_id": "openaddresses:address:data/input_file_2:25d52af880bfefc4",
     "_type": "doc",
     "data": {
       "name": {
@@ -272,12 +272,12 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:b87805454ead82d0"
+      "source_id": "data/input_file_2:25d52af880bfefc4"
     }
   },
   {
     "_index": "pelias",
-    "_id": "openaddresses:address:data/input_file_2:eba176e31fdf30d7",
+    "_id": "openaddresses:address:data/input_file_2:0d9cb0ba093a3d23",
     "_type": "doc",
     "data": {
       "name": {
@@ -296,7 +296,7 @@
       },
       "source": "openaddresses",
       "layer": "address",
-      "source_id": "data/input_file_2:eba176e31fdf30d7"
+      "source_id": "data/input_file_2:0d9cb0ba093a3d23"
     }
   }
 ]

--- a/test/streams/contentHashStream.js
+++ b/test/streams/contentHashStream.js
@@ -1,0 +1,117 @@
+const tape = require('tape');
+const event_stream = require('event-stream');
+const ContentHashStream = require('../../lib/streams/contentHashStream');
+const hash = ContentHashStream.hash;
+const DEFAULT_HASH = 'd41d8cd98f00b204';
+
+function test_stream(input, testedStream, callback) {
+  var input_stream = event_stream.readArray(input);
+  var destination_stream = event_stream.writeArray(callback);
+
+  input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+tape('contentHashStream generates new hash', function (test) {
+  var input = {
+    NUMBER: '5',
+    STREET: 'Abcd',
+    LAT: 5,
+    LON: 6,
+    POSTCODE: 'def'
+  };
+
+  var contentHashStream = ContentHashStream.create();
+
+  test_stream([input], contentHashStream, function (err, records) {
+    test.equal(records.length, 1, 'stream length unchanged');
+
+    var record = records[0];
+    test.equal(record.HASH, 'c2f8c35aa279ee7d', 'HASH field generated');
+    test.end();
+  });
+});
+
+tape('contentHashStream replaces existing hash', function (test) {
+  var input = {
+    NUMBER: '5 ',
+    STREET: ' Abcd ',
+    LAT: 5,
+    LON: 6,
+    POSTCODE: ' def ',
+    HASH: '54830a0a5bbbca8f'
+  };
+
+  var contentHashStream = ContentHashStream.create();
+
+  test_stream([input], contentHashStream, function (err, records) {
+    test.equal(records.length, 1, 'stream length unchanged');
+
+    var record = records[0];
+    test.equal(record.HASH, 'c2f8c35aa279ee7d', 'HASH field generated');
+    test.end();
+  });
+});
+
+tape('hash: default value for non-object and empty objects', function (test) {
+  test.equal(hash(null), DEFAULT_HASH);
+  test.equal(hash(1), DEFAULT_HASH);
+  test.equal(hash(false), DEFAULT_HASH);
+  test.equal(hash('string'), DEFAULT_HASH);
+  test.equal(hash([]), DEFAULT_HASH);
+  test.equal(hash({}), DEFAULT_HASH);
+  test.end();
+});
+
+tape('hash: 16 hexidecimal chars', function (test) {
+  const h = hash({ field: 'value' });
+  test.true(/[0-9A-Fa-f]{16}/g.test(h));
+  test.end();
+});
+
+tape('hash: strict equality', function (test) {
+  test.equal(
+    hash({ field1: 'A', field2: 'B' }),
+    hash({ field1: 'A', field2: 'B' })
+  );
+  test.end();
+});
+
+tape('hash: ingore existing hash field', function (test) {
+  test.equal(
+    hash({ field1: 'A', field2: 'B', hash: 'c2f8c35aa279ee7d' }),
+    hash({ field1: 'A', field2: 'B', HASH: 'deadb33fdeadb33f' })
+  );
+  test.end();
+});
+
+tape('hash: fuzzy equality', function (test) {
+  test.equal(
+    hash({ field1: 'A' }),
+    hash({ FIELD1: 'A' }),
+    'key case'
+  );
+  test.equal(
+    hash({ field1: 'A' }),
+    hash({ field1: 'a' }),
+    'value case'
+  );
+  test.equal(
+    hash({ field1: 'A' }),
+    hash({ field1: ' A ' }),
+    'value whitespace'
+  );
+  test.equal(
+    hash({ field1: 1 }),
+    hash({ field1: '1' }),
+    'value type'
+  );
+  test.end();
+});
+
+tape('hash: strict inequality', function (test) {
+  test.notEqual(
+    hash({ field1: 'A', field2: 'B' }),
+    hash({ field1: 'A', field9: 'B' })
+  );
+  test.end();
+});

--- a/test/streams/contentHashStream.js
+++ b/test/streams/contentHashStream.js
@@ -2,7 +2,7 @@ const tape = require('tape');
 const event_stream = require('event-stream');
 const ContentHashStream = require('../../lib/streams/contentHashStream');
 const hash = ContentHashStream.hash;
-const DEFAULT_HASH = 'd41d8cd98f00b204';
+const DEFAULT_HASH = 'ca9c491ac66b2c62';
 
 function test_stream(input, testedStream, callback) {
   var input_stream = event_stream.readArray(input);
@@ -26,7 +26,7 @@ tape('contentHashStream generates new hash', function (test) {
     test.equal(records.length, 1, 'stream length unchanged');
 
     var record = records[0];
-    test.equal(record.HASH, 'c2f8c35aa279ee7d', 'HASH field generated');
+    test.equal(record.HASH, 'f44048507e8fb319', 'HASH field generated');
     test.end();
   });
 });
@@ -47,71 +47,121 @@ tape('contentHashStream replaces existing hash', function (test) {
     test.equal(records.length, 1, 'stream length unchanged');
 
     var record = records[0];
-    test.equal(record.HASH, 'c2f8c35aa279ee7d', 'HASH field generated');
+    test.equal(record.HASH, 'f44048507e8fb319', 'HASH field generated');
     test.end();
   });
 });
 
 tape('hash: default value for non-object and empty objects', function (test) {
-  test.equal(hash(null), DEFAULT_HASH);
-  test.equal(hash(1), DEFAULT_HASH);
-  test.equal(hash(false), DEFAULT_HASH);
-  test.equal(hash('string'), DEFAULT_HASH);
-  test.equal(hash([]), DEFAULT_HASH);
-  test.equal(hash({}), DEFAULT_HASH);
+  test.equal(hash(null), DEFAULT_HASH, 'default hash');
+  test.equal(hash(1), DEFAULT_HASH, 'default hash');
+  test.equal(hash(false), DEFAULT_HASH, 'default hash');
+  test.equal(hash('string'), DEFAULT_HASH, 'default hash');
+  test.equal(hash([]), DEFAULT_HASH, 'default hash');
+  test.equal(hash({}), DEFAULT_HASH, 'default hash');
   test.end();
 });
 
-tape('hash: 16 hexidecimal chars', function (test) {
-  const h = hash({ field: 'value' });
-  test.true(/[0-9A-Fa-f]{16}/g.test(h));
+tape('hash: 16 lowercase hexidecimal chars', function (test) {
+  const conform = /^[0-9a-f]{16}$/;
+  for( let i=-90.0; i<+90.0; i+=0.5 ){
+    let h = hash({ LON: i, LAT: i });
+    test.true(conform.test(h), h);
+  }
   test.end();
 });
 
 tape('hash: strict equality', function (test) {
   test.equal(
-    hash({ field1: 'A', field2: 'B' }),
-    hash({ field1: 'A', field2: 'B' })
+    hash({ LON: '1.1', LAT: '2.2' }),
+    hash({ LON: '1.1', LAT: '2.2' })
+  );
+  test.equal(
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST' })
+  );
+  test.equal(
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10' })
+  );
+  test.equal(
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10', UNIT: '6B' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10', UNIT: '6B' })
   );
   test.end();
 });
 
 tape('hash: ingore existing hash field', function (test) {
   test.equal(
-    hash({ field1: 'A', field2: 'B', hash: 'c2f8c35aa279ee7d' }),
-    hash({ field1: 'A', field2: 'B', HASH: 'deadb33fdeadb33f' })
+    hash({ LON: '1.1', LAT: '2.2', HASH: 'c2f8c35aa279ee7d' }),
+    hash({ LON: '1.1', LAT: '2.2', HASH: 'deadb33fdeadb33f' })
   );
   test.end();
 });
 
 tape('hash: fuzzy equality', function (test) {
   test.equal(
-    hash({ field1: 'A' }),
-    hash({ FIELD1: 'A' }),
-    'key case'
-  );
-  test.equal(
-    hash({ field1: 'A' }),
-    hash({ field1: 'a' }),
+    hash({ STREET: 'A ST' }),
+    hash({ STREET: 'a st' }),
     'value case'
   );
   test.equal(
-    hash({ field1: 'A' }),
-    hash({ field1: ' A ' }),
+    hash({ STREET: 'A ST' }),
+    hash({ STREET: ' A  ST  ' }),
     'value whitespace'
   );
   test.equal(
-    hash({ field1: 1 }),
-    hash({ field1: '1' }),
+    hash({ STREET: 1 }),
+    hash({ STREET: '1' }),
     'value type'
+  );
+  test.equal(
+    hash({ LON: 1.123456789 }),
+    hash({ LON: 1.1234567 }),
+    'float precision'
+  );
+  test.equal(
+    hash({ LON: 1.12000000000 }),
+    hash({ LON: 1.12 }),
+    'float precision'
+  );
+  test.equal(
+    hash({ LON: -1.000000000000 }),
+    hash({ LON: -1 }),
+    'float precision'
+  );
+  test.equal(
+    hash({ LON: 0 }),
+    hash({ LON: -0 }),
+    'negative zero'
   );
   test.end();
 });
 
 tape('hash: strict inequality', function (test) {
   test.notEqual(
-    hash({ field1: 'A', field2: 'B' }),
-    hash({ field1: 'A', field9: 'B' })
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10', UNIT: '6B' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10', UNIT: '6' })
+  );
+  test.notEqual(
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '10' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST', NUMBER: '11' })
+  );
+  test.notEqual(
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A ST' }),
+    hash({ LON: '1.1', LAT: '2.2', STREET: 'A RD' })
+  );
+  test.notEqual(
+    hash({ LON: '1.1', LAT: '2.2' }),
+    hash({ LON: '1.1', LAT: '2.1' })
+  );
+  test.notEqual(
+    hash({ LON: '1.1' }),
+    hash({ LON: '-1.1' })
+  );
+  test.notEqual(
+    hash({ NUMBER: '10' }),
+    hash({ UNIT: '10' })
   );
   test.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,7 @@ require( './import');
 require( './importPipeline');
 require( './parameters' );
 require( './streams/cleanupStream' );
+require( './streams/contentHashStream' );
 require( './streams/documentStream' );
 require( './streams/germanicAbbreviationStream');
 require( './streams/isUSorCAHouseNumberZero' );


### PR DESCRIPTION
Following on from a discussion with the OA team, we will begin generating our own content hashes for each row of the CSV file.

The original intention of the `HASH` field was to provide a semi-stable identifier for each row in order to:
- provide an addressable identifier for each row
- facilitate deduplication between imports (such as duplicates in the `us/or/portland_metro` and `us/or/portland` files).
- allow for blacklisting of records using their GID

It turns out that the existing `HASH` column generated by the OA team is [seeded with a random number](https://github.com/openaddresses/machine/blob/b08a622669af7d896739f87891c13ca8b527b5b9/openaddr/conform.py#L1003), so even if the underlying data remains the same, the hash value will change with each rebuild of the OA file.

eg:
```bash
grep 4012 565265_portland_grep.txt 677463_portland_grep.txt
565265_portland_grep.txt:-122.6474699,45.4909803,4012,SE 17TH AVE,,PORTLAND,MULTNOMAH,OR,97202,,9fc860391a6ce4df
677463_portland_grep.txt:-122.6474699,45.4909803,4012,SE 17TH AVE,,PORTLAND,MULTNOMAH,OR,97202,,18eb1f0f484d2e7e
```

This PR puts the responsibility of hash generation on us, it's pretty simple and open for feedback.