### PR TITLE
Run curl silently to avoid using up all of the stdout/stderr buffer.

### DIFF
--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -39,7 +39,7 @@ function downloadBundle(targetDir, sourceUrl, callback) {
       // download the zip file into the temp directory
       (callback) => {
         logger.debug(`downloading ${sourceUrl}`);
-        child_process.exec(`curl -L -X GET -o ${tmpZipFile} ${sourceUrl}`, callback);
+        child_process.exec(`curl -s -L -X GET -o ${tmpZipFile} ${sourceUrl}`, callback);
       },
       // unzip file into target directory
       (callback) => {

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -75,7 +75,7 @@ function downloadSource(targetDir, file, main_callback) {
       // download the zip file into the temp directory
       (callback) => {
         logger.debug(`downloading ${file.url}`);
-        child_process.exec(`curl -L -X GET -o ${file.zip} ${file.url}`, callback);
+        child_process.exec(`curl -s -L -X GET -o ${file.zip} ${file.url}`, callback);
       },
       // unzip file into target directory
       (callback) => {


### PR DESCRIPTION
On versions of Node older than 12.x, the maxBuffer size is significantly smaller.  While I was trying to run the openaddresses downloader, I noticed that my downloads kept failing because the buffer was filling up.  

This was caused by the progress output being sent to stdout/stderr from curl.  This PR just changes the curl command to run silently to avoid ever filling up the buffer causing your download to fail.