### PR TITLE
Update test expectations for new doc type name

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.16.0",
     "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",
-    "pelias-config": "^4.5.0",
+    "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -2,7 +2,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_1:7552fdd1d9eb5765",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "100 Main St"
@@ -110,7 +110,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_1:e21716b47966b98a",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "200 Main St"
@@ -134,7 +134,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_1:7456321cc7d6d352",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "0 Main St"
@@ -158,7 +158,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_1:f026cd5494a7e4f4",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "00 Elm St"
@@ -182,7 +182,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_1:4509c0194f1efaca",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "00300 Main St"
@@ -206,7 +206,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_2:fc6d8b0a0e5cda70",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "400 Vireo Rd"
@@ -230,7 +230,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_2:b7c25b5e6eea7831",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "00000 Vireo Rd"
@@ -254,7 +254,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_2:25d52af880bfefc4",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "00500 Calle De Lago"
@@ -278,7 +278,7 @@
   {
     "_index": "pelias",
     "_id": "openaddresses:address:data/input_file_2:0d9cb0ba093a3d23",
-    "_type": "doc",
+    "_type": "_doc",
     "data": {
       "name": {
         "default": "00500 Calle De Lago"


### PR DESCRIPTION
As of `pelias-config@4.8.0`, the default Elasticsearch type name is now `_doc`, which is the value compatible with Elasticsearch 7.

This PR updates the functional tests to expect that new value and ensures that the appropriate version of `pelias-config` is used going forward.

Connects https://github.com/pelias/config/pull/122
Connects https://github.com/pelias/pelias/issues/831
Fixes https://github.com/pelias/openaddresses/issues/450