### PR TITLE
move away from event-stream, replace with stream-mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,10 @@
     "tmp": "^0.1.0"
   },
   "devDependencies": {
-    "deep-diff": "^1.0.0",
-    "event-stream": "^4.0.0",
     "jshint": "^2.9.4",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
+    "stream-mock": "^2.0.3",
     "tap-spec": "^5.0.0",
     "tape": "^4.10.1",
     "temp": "^0.9.0"

--- a/test/streams/cleanupStream.js
+++ b/test/streams/cleanupStream.js
@@ -1,13 +1,15 @@
 var tape = require( 'tape' );
-var event_stream = require( 'event-stream' );
 
 var CleanupStream = require( '../../lib/streams/cleanupStream' );
 
-function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-  input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'cleanupStream trims whitespace from all fields', function(test) {

--- a/test/streams/contentHashStream.js
+++ b/test/streams/contentHashStream.js
@@ -1,14 +1,15 @@
 const tape = require('tape');
-const event_stream = require('event-stream');
+const stream_mock = require('stream-mock');
 const ContentHashStream = require('../../lib/streams/contentHashStream');
 const hash = ContentHashStream.hash;
 const DEFAULT_HASH = 'ca9c491ac66b2c62';
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('contentHashStream generates new hash', function (test) {

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -1,13 +1,15 @@
 const tape = require( 'tape' );
-const event_stream = require( 'event-stream' );
+
+const stream_mock = require('stream-mock');
 
 const DocumentStream = require( '../../lib/streams/documentStream' );
 
 function test_stream(input, testedStream, callback) {
-  const input_stream = event_stream.readArray(input);
-  const destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'documentStream catches records with no street', function(test) {

--- a/test/streams/germanicAbbreviationStream.js
+++ b/test/streams/germanicAbbreviationStream.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require( 'event-stream' );
+const stream_mock = require('stream-mock');
 
 var germanicStream = require( '../../lib/streams/germanicAbbreviationStream' );
 
 function test_stream(input, testedStream, callback) {
-  var input_stream = event_stream.readArray(input);
-  var destination_stream = event_stream.writeArray(callback);
-
-  input_stream.pipe(testedStream).pipe(destination_stream);
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape( 'germanicStream expands tokens ending in "-str." to "-strasse" (mostly DEU)', function(test) {

--- a/test/streams/isUSorCAHouseNumberZero.js
+++ b/test/streams/isUSorCAHouseNumberZero.js
@@ -1,13 +1,14 @@
 var tape = require('tape');
-var event_stream = require('event-stream');
-
 var isUSorCAHouseNumberZero = require('../../lib/streams/isUSorCAHouseNumberZero');
 
-function test_stream(input, testedStream, callback) {
-    var input_stream = event_stream.readArray(input);
-    var destination_stream = event_stream.writeArray(callback);
+const stream_mock = require('stream-mock');
 
-    input_stream.pipe(testedStream).pipe(destination_stream);
+function test_stream(input, testedStream, callback) {
+  const reader = new stream_mock.ObjectReadableMock(input);
+  const writer = new stream_mock.ObjectWritableMock();
+  writer.on('error', (e) => callback(e));
+  writer.on('finish', () => callback(null, writer.data));
+  reader.pipe(testedStream).pipe(writer);
 }
 
 tape('isUSorCAHouseNumberZero', function(t) {


### PR DESCRIPTION
closes https://github.com/pelias/openaddresses/pull/429 as replacement
I pulled the code from `benetis` and cleaned up the tests as per `orangejulius` comments so we can merge this.
Also rebased `master` and fixed one tests. that came in since the original PR.
