### PR TITLE
feat(deps): Remove fs-extra package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "bottleneck": "^2.19.5",
     "combined-stream": "^1.0.7",
     "csv-parse": "^4.0.0",
-    "fs-extra": "^8.1.0",
     "glob": "^7.0.0",
     "lodash": "^4.16.0",
     "minimist": "^1.2.0",

--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -1,6 +1,6 @@
 const child_process = require('child_process');
 const async = require('async');
-const fs = require('fs-extra');
+const fs = require('fs');
 const tmp = require('tmp');
 const logger = require('pelias-logger').get('openaddresses-download');
 
@@ -9,7 +9,7 @@ function downloadAll(config, callback) {
 
   const targetDir = config.imports.openaddresses.datapath;
 
-  fs.ensureDir(targetDir, (err) => {
+  fs.mkdir(targetDir, { recursive: true }, (err) => {
     if (err) {
       logger.error(`error making directory ${targetDir}`, err);
       return callback(err);

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process');
 const config = require( 'pelias-config' ).generate();
 const async = require('async');
-const fs = require('fs-extra');
+const fs = require('fs');
 const tmp = require('tmp');
 const logger = require('pelias-logger').get('openaddresses-download');
 const Bottleneck = require('bottleneck/es5');
@@ -9,7 +9,7 @@ const Bottleneck = require('bottleneck/es5');
 function downloadFiltered(config, callback) {
   const targetDir = config.imports.openaddresses.datapath;
 
-  fs.ensureDir(targetDir, (err) => {
+  fs.mkdir(targetDir, { recursive: true }, (err) => {
     if (err) {
       logger.error(`error making directory ${targetDir}`, err);
       return callback(err);


### PR DESCRIPTION
We generally only use the fs-extra package for its `mkdir -p` style convenience wrapper, which can now easily be done with the stock `fs` module.

This removes usage of the fs-extra module and replaces it with native alternatives.

Closes https://github.com/pelias/openaddresses/pull/458