### PR TITLE
feat(logs): Remove bad record count verbose logger

### DIFF
--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -47,10 +47,6 @@ function createRecordStream( filePath, dirPath ){
     badRecordCount: 0
   };
 
-  var intervalId = setInterval( function (){
-    logger.verbose( 'Number of bad records: ' + stats.badRecordCount );
-  }, 10000 );
-
   const csvParser = csvParse({
     trim: true,
     skip_empty_lines: true,
@@ -66,7 +62,6 @@ function createRecordStream( filePath, dirPath ){
   const documentStream = DocumentStream.create(idPrefix, stats);
 
   documentStream._flush = function end( done ){
-    clearInterval( intervalId );
     done();
   };
 


### PR DESCRIPTION
This log has always been a pain. It's on a simple 10 second timer so it will print forever, even if nothing has changed.

It's measuring the number of records that were invalid, which is not a particularly notable thing. There are invalid records in OA data all the time.

Overall, we don't really need this and it's just cluttering up other, more important, log output.