### PR TITLE
fix(deps): Upgrade wof-admin-lookup to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",
-    "pelias-wof-admin-lookup": "^7.0.0",
+    "pelias-wof-admin-lookup": "^7.1.1",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
We want to ensure the fix for https://github.com/pelias/wof-admin-lookup/issues/288, contained in https://github.com/pelias/wof-admin-lookup/pull/297, is used when importing.