### PR TITLE
Revert "Update tmp to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",
     "through2-sink": "^1.0.0",
-    "tmp": "^0.2.0"
+    "tmp": "^0.1.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4",


### PR DESCRIPTION
Reverts pelias/openaddresses#466

Unfortunately I have to revert this change because the authors of `npm tmp` don't adhere to the semantic versioning spec and have recently been publishing a bunch of breaking changes under the minor versions `0.2.x` 😢 

More specifically, the following change was introduced in a minor version which broke our download script:

```bash
# version 0.1.0
> require('tmp').tmpNameSync({prefix: 'foo', dir: '/code', postfix: '.zip'})
'/code/foo16hKdNdr67yY0D.zip'

# version 0.2.1
> require('tmp').tmpNameSync({prefix: 'foo', dir: '/code', postfix: '.zip'})
Thrown:
Error: dir option must be relative to "/tmp", found "/code".
    at _assertIsRelative (/code/pelias/openaddresses/node_modules/tmp/lib/tmp.js:599:13)
    at _assertAndSanitizeOptions (/code/pelias/openaddresses/node_modules/tmp/lib/tmp.js:513:5)
    at Object.tmpNameSync (/code/pelias/openaddresses/node_modules/tmp/lib/tmp.js:105:3)
```