### PR TITLE
use npm "temp" instead of npm "tmp"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "pelias-logger": "^1.2.1",
     "pelias-model": "^7.1.0",
     "pelias-wof-admin-lookup": "^7.3.0",
+    "temp": "^0.9.1",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",
-    "through2-sink": "^1.0.0",
-    "tmp": "^0.1.0"
+    "through2-sink": "^1.0.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4",
@@ -34,8 +34,7 @@
     "proxyquire": "^2.0.0",
     "stream-mock": "^2.0.3",
     "tap-spec": "^5.0.0",
-    "tape": "^5.0.0",
-    "temp": "^0.9.0"
+    "tape": "^5.0.0"
   },
   "scripts": {
     "download": "./bin/download",

--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -1,7 +1,7 @@
 const child_process = require('child_process');
 const async = require('async');
 const fs = require('fs-extra');
-const tmp = require('tmp');
+const temp = require('temp');
 const logger = require('pelias-logger').get('openaddresses-download');
 
 function downloadAll(config, callback) {
@@ -32,7 +32,7 @@ function downloadAll(config, callback) {
 
 function downloadBundle(targetDir, sourceUrl, callback) {
 
-  const tmpZipFile = tmp.tmpNameSync({postfix: '.zip'});
+  const tmpZipFile = temp.path({suffix: '.zip'});
 
   async.series(
     [

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -2,7 +2,7 @@ const child_process = require('child_process');
 const config = require( 'pelias-config' ).generate();
 const async = require('async');
 const fs = require('fs-extra');
-const tmp = require('tmp');
+const temp = require('temp');
 const logger = require('pelias-logger').get('openaddresses-download');
 const Bottleneck = require('bottleneck/es5');
 
@@ -61,7 +61,7 @@ function getFiles(config, targetDir, main_callback){
     return {
       csv: file,
       url: `https://results.openaddresses.io/latest/run/${source}`,
-      zip: tmp.tmpNameSync({prefix: name, dir: targetDir, postfix: '.zip'})
+      zip: temp.path({prefix: name, dir: targetDir, suffix: '.zip'})
     };
   });
 }


### PR DESCRIPTION
use npm "temp" instead of npm "tmp".

It doesn't make much sense to have both modules when `temp` can do everything `tmp` does 🤷 
The documentation for `temp` isn't super clear on the usage of `.path()` (edit: [this is the relevant part](https://github.com/bruce/node-temp#affixes)), it's a bit clearer by [looking at the code](https://github.com/bruce/node-temp/blob/master/lib/temp.js#L43-L73).

This code isn't covered by unit tests so this PR is DRAFT until I can figure out how to manually test it.