### PR TITLE
Allow download from s3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y unzip awscli && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/openaddresses

--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ downloading customized data. Paths are supported (for example,
 `https://yourhost.com/path/to/your/data`), but must not end with a trailing
 slash.
 
+S3 buckets are supported. Files will be downloaded using aws-cli.
+
+For example: `s3://data.openaddresses.io`.
+
+Note: When using s3, you might need authentcation (IAM instance role, env vars, etc.)
+
+### `imports.openaddresses.s3Options`
+
+* Required: no
+
+If `imports.openaddresses.dataHost` is an s3 bucket, this will add options to the command.
+For example: `--profile my-profile`
+
+This is useful, for example, when downloading from `s3://data.openaddresses.io`,
+as they require the requester to pay for data transfer.
+You can then use the following option: `--request-payer`
+
 ## Parallel Importing
 
 Because OpenAddresses consists of many small files, this importer can be configured to run several instances in parallel that coordinate to import all the data.

--- a/schema.js
+++ b/schema.js
@@ -10,6 +10,7 @@ module.exports = Joi.object().keys({
       files: Joi.array().items(Joi.string()),
       datapath: Joi.string().required(true),
       dataHost: Joi.string(),
+      s3Options: Joi.string(),
       adminLookup: Joi.boolean(),
       missingFilesAreFatal: Joi.boolean().default(false).truthy('yes').falsy('no')
     }).unknown(false)


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

Downloading from `https://data.openaddresses.io` is extremely slow, as they are throttling all downloads.
I could not find any mirror out there and the only solution to fast download I found was S3, with the [requester pays](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html) option.

---
#### Here's what actually got changed :clap:
I added an option to allow downloading the oa files from S3, with the possibility to add options like `--request-payer`. This speeds up the download extremely, with the only inconvenient that you'll have to pay for the data transfer.

---
#### Here's how others can test the changes :eyes:

Use the following options in `pelias.json`

```json
"openaddresses": {
      "dataHost": "s3://data.openaddresses.io",
      "s3Options": "--request-payer",
      "datapath": "/data/openaddresses",
      "files": []
}
```

Note: Authentication is required. A good way to do that is to add access keys in the `docker-compose.yml` file

```yml
  openaddresses:
    image: pelias/openaddresses:latest
    container_name: pelias_openaddresses
    user: "${DOCKER_USER}"
    environment: 
      - "AWS_ACCESS_KEY_ID=XYZ......."
      - "AWS_SECRET_ACCESS_KEY=123..........."
```