### PR TITLE
add referer header to cURL requests

### DIFF
--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -34,6 +34,7 @@ function downloadAll(config, callback) {
 function downloadBundle(targetDir, config, sourceUrl, callback) {
 
   const tmpZipFile = temp.path({suffix: '.zip'});
+  const referer = config.get('imports.openaddresses.dataReferer') || 'https://pelias-results.openaddresses.io';
 
   async.series(
     [
@@ -44,7 +45,7 @@ function downloadBundle(targetDir, config, sourceUrl, callback) {
           const s3Options = config.imports.openaddresses.s3Options || '';
           child_process.exec(`aws s3 cp ${sourceUrl} ${tmpZipFile} ${s3Options}`, callback);
         } else {
-          child_process.exec(`curl -s -L -X GET -o ${tmpZipFile} ${sourceUrl}`, callback);
+          child_process.exec(`curl -s -L -X GET --referer ${referer} -o ${tmpZipFile} ${sourceUrl}`, callback);
         }
       },
       // unzip file into target directory

--- a/utils/download_filtered.js
+++ b/utils/download_filtered.js
@@ -68,6 +68,7 @@ function getFiles(config, targetDir, main_callback){
 
 function downloadSource(targetDir, file, main_callback) {
   const errorsFatal = config.get('imports.openaddresses.missingFilesAreFatal');
+  const referer = config.get('imports.openaddresses.dataReferer') || 'https://pelias-results.openaddresses.io';
   logger.info(`Downloading ${file.csv}`);
 
   async.series(
@@ -75,7 +76,7 @@ function downloadSource(targetDir, file, main_callback) {
       // download the zip file into the temp directory
       (callback) => {
         logger.debug(`downloading ${file.url}`);
-        child_process.exec(`curl -s -L -X GET -o ${file.zip} ${file.url}`, callback);
+        child_process.exec(`curl -s -L -X GET --referer ${referer} -o ${file.zip} ${file.url}`, callback);
       },
       // unzip file into target directory
       (callback) => {


### PR DESCRIPTION
As discussed in https://github.com/pelias/openaddresses/issues/482 this PR adds a referer header to cURL requests sent to download data from `results.openaddresses.io`.

requires confirmation that it works as expected before merging.
closes https://github.com/pelias/openaddresses/issues/482