### PR TITLE
street_name_normalization: contract english diagonals

### DIFF
--- a/lib/analysis/dictionaries/en/diagonal_contractions.txt
+++ b/lib/analysis/dictionaries/en/diagonal_contractions.txt
@@ -1,0 +1,4 @@
+SE|southeast
+SW|southwest
+NE|northeast
+NW|northwest

--- a/lib/cleanup_v2.js
+++ b/lib/cleanup_v2.js
@@ -28,6 +28,11 @@ const dict = {
     filename: 'directional_expansions.txt',
     includeSelfReferences: true
   }),
+  diagonalContractions: dictionary({
+    countryCode: 'en',
+    filename: 'diagonal_contractions.txt',
+    includeSelfReferences: false
+  }),
   streetTypes: _.merge(
     dictionary({
       countryCode: 'en',
@@ -94,6 +99,15 @@ function cleanupStreetName(input) {
     tokens = synonyms({
       dictionary: dict.directionalExpansions,
       maxElements: 1,
+      maxReplacements: 1,
+      direction: 'left'
+    })(tokens);
+  }
+
+  // diagonal contractions (all tokens)
+  if (tokens.length >= 3) {
+    tokens = synonyms({
+      dictionary: dict.diagonalContractions,
       maxReplacements: 1,
       direction: 'left'
     })(tokens);

--- a/test/cleanup_v2.js
+++ b/test/cleanup_v2.js
@@ -104,7 +104,7 @@ tape('generic expansion - multiple generic tokens', (t) => {
 
 // @todo: what should we do when the 'generic' preceeds the 'specific'?
 // @note: currently this expands 'Ave S' but not 'Ave X' because it thinks
-// that S refers to a diagonal.
+// that S refers to a directional.
 tape('generic expansion - multiple generic tokens', (t) => {
   t.equal(analyzer('AVE X'), 'Ave X');
   t.equal(analyzer('AVE S'), 'Avenue S');
@@ -131,9 +131,7 @@ tape('expand directionals - last token position', (t) => {
   t.end();
 });
 
-// ignore diagonals
-// note: for now we will ignore diagonals since the expanded
-// for can we quite long.
+// do not expand NSEW directionals
 tape('expand directionals - first token position', (t) => {
   t.equal(analyzer('NE Main Street'), 'NE Main Street');
   t.equal(analyzer('SE Main Street'), 'SE Main Street');
@@ -164,6 +162,22 @@ tape('expand directionals - unless followed by a generic', (t) => {
   t.equal(analyzer('N Street Station'), 'N Street Station');
   t.equal(analyzer('N Ave Junction'), 'N Ave Junction');
   t.equal(analyzer('N Avenue Junction'), 'N Avenue Junction');
+  t.end();
+});
+
+// contract english diagonals (southwest,southeast...)
+tape('contract english diagonals - first token position', (t) => {
+  t.equal(analyzer('Northeast Main Street'), 'NE Main Street');
+  t.equal(analyzer('Southeast Main Street'), 'SE Main Street');
+  t.equal(analyzer('Northwest Main Street'), 'NW Main Street');
+  t.equal(analyzer('Southwest Main Street'), 'SW Main Street');
+  t.end();
+});
+tape('contract english diagonals - last token position', (t) => {
+  t.equal(analyzer('Main Street Northeast'), 'Main Street NE');
+  t.equal(analyzer('Main Street Southeast'), 'Main Street SE');
+  t.equal(analyzer('Main Street Northwest'), 'Main Street NW');
+  t.equal(analyzer('Main Street Southwest'), 'Main Street SW');
   t.end();
 });
 


### PR DESCRIPTION
as a follow on from https://github.com/pelias/openaddresses/pull/477 and pairing with https://github.com/pelias/openstreetmap/pull/560 this PR contracts English diagonals in street names.

it only targets four terms `["southeast", "southwest", "northeast", "northwest"`], when those tokens are found they are replaced with the contracted form `[SE, SW, NE, NW]`.

as such it's pretty safe