### PR TITLE
download: suppress progress indicator for aws s3 cp command

### DIFF
--- a/utils/download_all.js
+++ b/utils/download_all.js
@@ -43,7 +43,7 @@ function downloadBundle(targetDir, config, sourceUrl, callback) {
         logger.debug(`downloading ${sourceUrl}`);
         if (_.startsWith(sourceUrl, 's3://')) {
           const s3Options = config.imports.openaddresses.s3Options || '';
-          child_process.exec(`aws s3 cp ${sourceUrl} ${tmpZipFile} ${s3Options}`, callback);
+          child_process.exec(`aws s3 cp ${sourceUrl} ${tmpZipFile} --only-show-errors ${s3Options}`, callback);
         } else {
           child_process.exec(`curl -s -L -X GET --referer ${referer} -o ${tmpZipFile} ${sourceUrl}`, callback);
         }


### PR DESCRIPTION
as discussed in https://github.com/pelias/docker/issues/266 the `aws s3 cp` command outputs regular progress information to `stdout`.

since we're using `child_process.exec` the `stdout` is buffered until the process exits, if the buffer (1MB by default) fills up then an error occurs.

we're not using the return value of `child_process.exec` (from what I could tell), so adding [--only-show-errors](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html) suppresses it, while also not having to worry about conflicting/duplicate `--no-progress` flags provided by the user.

if we would like to return regular status reports of the file as it downloads then we would need to change `child_process.exec` to `child_process.spawn` and refactor accordingly, the latter allows customisation of the `stdio` config for `stdout` whereas the former does not.

resolves https://github.com/pelias/docker/issues/266