### PR TITLE
strip byte-order-mark from CSV files

### DIFF
--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -1,13 +1,12 @@
-const fs = require( 'fs' );
-const path = require( 'path' );
-
-const csvParse = require( 'csv-parse' );
-const combinedStream = require( 'combined-stream' );
-const _ = require( 'lodash' );
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const csvParse = require('csv-parse').parse;
+const combinedStream = require('combined-stream');
 const through = require('through2');
 const split = require('split2');
 
-const logger = require( 'pelias-logger' ).get( 'openaddresses' );
+const logger = require('pelias-logger').get('openaddresses');
 const config = require('pelias-config').generate();
 
 const CleanupStream = require('./cleanupStream');
@@ -100,6 +99,7 @@ function fileStreamDispatcher(stream, filePath) {
   }
 
   return stream.pipe(csvParse({
+    bom: true,
     trim: true,
     skip_empty_lines: true,
     relax_column_count: true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "async": "^3.1.0",
     "bottleneck": "^2.19.5",
     "combined-stream": "^1.0.7",
-    "csv-parse": "^4.0.0",
+    "csv-parse": "^5.0.3",
     "fs-extra": "^8.1.0",
     "glob": "^7.0.0",
     "lodash": "^4.16.0",


### PR DESCRIPTION
same as https://github.com/pelias/csv-importer/pull/93 (including npm version bump)
resolves https://github.com/pelias/openaddresses/issues/494
