### PR TITLE
upgrade pelias-model to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
-    "pelias-model": "^7.1.0",
+    "pelias-model": "^9.1.1",
     "pelias-wof-admin-lookup": "^7.4.1",
     "split2": "^3.2.2",
     "temp": "^0.9.1",

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -20,6 +20,9 @@
         "country_a": [
           null
         ],
+        "country_source": [
+          null
+        ],
         "macroregion": [
           "override macroregion"
         ],
@@ -27,6 +30,9 @@
           "2"
         ],
         "macroregion_a": [
+          null
+        ],
+        "macroregion_source": [
           null
         ],
         "region": [
@@ -38,6 +44,9 @@
         "region_a": [
           null
         ],
+        "region_source": [
+          null
+        ],
         "macrocounty": [
           "override macrocounty"
         ],
@@ -45,6 +54,9 @@
           "4"
         ],
         "macrocounty_a": [
+          null
+        ],
+        "macrocounty_source": [
           null
         ],
         "county": [
@@ -56,6 +68,9 @@
         "county_a": [
           null
         ],
+        "county_source": [
+          null
+        ],
         "borough": [
           "override borough"
         ],
@@ -63,6 +78,9 @@
           "6"
         ],
         "borough_a": [
+          null
+        ],
+        "borough_source": [
           null
         ],
         "locality": [
@@ -74,6 +92,9 @@
         "locality_a": [
           null
         ],
+        "locality_source": [
+          null
+        ],
         "localadmin": [
           "override localadmin"
         ],
@@ -83,6 +104,9 @@
         "localadmin_a": [
           null
         ],
+        "localadmin_source": [
+          null
+        ],
         "neighbourhood": [
           "override neighbourhood"
         ],
@@ -90,6 +114,9 @@
           "9"
         ],
         "neighbourhood_a": [
+          null
+        ],
+        "neighbourhood_source": [
           null
         ]
       },

--- a/test/importPipeline.js
+++ b/test/importPipeline.js
@@ -16,7 +16,7 @@ tape('functional test of importing two small OA files', function(t) {
     // uncomment this to write the actual results to the expected file
     // make sure they look ok though. comma left off so jshint reminds you
     // not to commit this line
-    // fs.writeFileSync(expectedPath, JSON.stringify(actual, null, 2))
+    // require('fs').writeFileSync(expectedPath, JSON.stringify(actual, null, 2))
 
     t.error(err);
     t.deepEquals(actual, expected);


### PR DESCRIPTION
this PR upgrades `pelias/model` to the latest version.

looking through [the changelog](https://github.com/pelias/model/releases) there is nothing which will effect the OA importer, which is probably why we didn't do this sooner.