### PR TITLE
gnaf: silence gnaf mapper warning when ID field is undefined

### DIFF
--- a/lib/streams/gnafMapperStream.js
+++ b/lib/streams/gnafMapperStream.js
@@ -17,7 +17,7 @@ module.exports = function () {
 
         // detect Australian G-NAF PID concordances
         const oaid = _.get(doc.getMeta('oa'), 'ID');
-        if (oaid.length === 14 && oaid.match(GNAF_PID_PATTERN)) {
+        if (_.isString(oaid) && oaid.length === 14 && oaid.match(GNAF_PID_PATTERN)) {
           doc.setAddendum('concordances', { 'gnaf:pid': oaid });
         }
       }

--- a/test/streams/gnafMapperStream.js
+++ b/test/streams/gnafMapperStream.js
@@ -43,11 +43,32 @@ module.exports.tests.au_gnaf_id = function (test) {
   });
 };
 
-module.exports.tests.non_au_gnaf_id = function (test) {
+module.exports.tests.au_invalid_gnaf_id = function (test) {
   var doc = new Document('oa', 'a', 1);
   doc.setMeta('country_code', 'AU');
   doc.setMeta('oa', {
     ID: 'invalid', // note: invalid GNAF ID
+    NUMBER: '360',
+    STREET: 'BRUNSWICK STREET',
+    LAT: -37.79647546,
+    LON: 144.978997
+  });
+  test('maps - GNAF ID', t => {
+    var stream = mapper();
+    stream.pipe(through.obj((doc, enc, next) => {
+      t.deepEqual(doc.getAddendum('concordances'), undefined);
+      t.end();
+      next();
+    }));
+    stream.write(doc);
+  });
+};
+
+module.exports.tests.au_missing_id_field = function (test) {
+  var doc = new Document('oa', 'a', 1);
+  doc.setMeta('country_code', 'AU');
+  doc.setMeta('oa', {
+    ID: undefined, // note: missing ID field
     NUMBER: '360',
     STREET: 'BRUNSWICK STREET',
     LAT: -37.79647546,


### PR DESCRIPTION
as reported in Gitter, a warning is emitted when the source data doesn't have a valid `ID` column.
I thought this was impossible, apparently not.

good news is it's only a warning and the rest of the importer will continue as expected, this PR silences it.