### PR TITLE
Upgrade to wof-admin-lookup 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^9.2.0",
-    "pelias-wof-admin-lookup": "^7.4.1",
+    "pelias-wof-admin-lookup": "^7.7.0",
     "split2": "^3.2.2",
     "temp": "^0.9.1",
     "through2": "^3.0.0",


### PR DESCRIPTION
This includes the changes in https://github.com/pelias/wof-admin-lookup/pull/311 that help with using the `boundary.country` API parameter with `dependency` placetypes.