### PR TITLE
fix: remove split2 from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "jshint": "^2.9.4",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
-    "split2": "^3.2.2",
     "stream-mock": "^2.0.3",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.0"


### PR DESCRIPTION
The package `split2` is present in both `dependencies` and `devDependencies`.

This causes an `MODULE_NOT_FOUND` error when we install the project with `npm install --omit=dev`

```
node:internal/modules/cjs/loader:998
  throw err;
  ^

Error: Cannot find module 'split2'
Require stack:
- /opt/pelias/lib/streams/recordStream.js
- /opt/pelias/lib/importPipeline.js
- /opt/pelias/import.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:995:15)
    at Function.Module._load (node:internal/modules/cjs/loader:841:27)
    at Module.require (node:internal/modules/cjs/loader:1067:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/opt/pelias/lib/streams/recordStream.js:7:15)
    at Module._compile (node:internal/modules/cjs/loader:1165:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1219:10)
    at Module.load (node:internal/modules/cjs/loader:1043:32)
    at Function.Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1067:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/pelias/lib/streams/recordStream.js',
    '/opt/pelias/lib/importPipeline.js',
    '/opt/pelias/import.js'
  ]
}
```

Node version: 16