### PR TITLE
recordStream: document ids should end with `.geojson`

### DIFF
--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -26,13 +26,13 @@ function getIdPrefix(filename, dirPath) {
     // of the directory tree to create the id
     if (filename.indexOf(dirPath) !== -1) {
       var subpath = _.replace(filename, dirPath, '');
-      var prefix = _.replace(subpath, '.csv', '');
+      var prefix = _.replace(subpath, /\.(csv|geojson)/, '');
       return _.trim(prefix, '/');
     }
   }
 
   // if the dirPath doesn't contain this file, return the basename without extension
-  return path.basename(filename, '.csv');
+  return path.basename(path.basename(filename, '.csv'), '.geojson');
 }
 
 /**

--- a/test/streams/recordStream.js
+++ b/test/streams/recordStream.js
@@ -62,7 +62,7 @@ tape( 'Don\'t create records for invalid data.', function ( test ){
   ));
 });
 
-tape( 'getIdPrefix returns prefix based on OA directory structure', function( test ) {
+tape( 'getIdPrefix returns prefix based on OA directory structure - csv', function( test ) {
   var filename = '/base/path/us/ca/san_francisco.csv';
   var basePath = '/base/path';
 
@@ -73,7 +73,7 @@ tape( 'getIdPrefix returns prefix based on OA directory structure', function( te
   test.end();
 });
 
-tape( 'getIdPrefix handles multiple levels of heirarchy', function ( test ) {
+tape( 'getIdPrefix handles multiple levels of heirarchy - csv', function ( test ) {
   var filename = '/base/path/cz/countrywide.csv';
   var basePath = '/base/path';
 
@@ -84,8 +84,41 @@ tape( 'getIdPrefix handles multiple levels of heirarchy', function ( test ) {
   test.end();
 });
 
-tape( 'getIdPrefix returns basename without extension when invalid basepath given', function( test ) {
+tape( 'getIdPrefix returns basename without extension when invalid basepath given - csv', function( test ) {
   var filename = '/path/to/a/document.csv';
+  var basePath = '/somewhere/else';
+
+  var actual = recordStream.getIdPrefix(filename, basePath);
+  var expected = 'document';
+
+  test.equal(actual, expected);
+  test.end();
+});
+
+tape( 'getIdPrefix returns prefix based on OA directory structure - geojson', function( test ) {
+  var filename = '/base/path/us/ca/san_francisco.geojson';
+  var basePath = '/base/path';
+
+  var actual = recordStream.getIdPrefix(filename, basePath);
+
+  var expected = 'us/ca/san_francisco';
+  test.equal(actual, expected, 'correct prefix generated');
+  test.end();
+});
+
+tape( 'getIdPrefix handles multiple levels of heirarchy - geojson', function ( test ) {
+  var filename = '/base/path/cz/countrywide.geojson';
+  var basePath = '/base/path';
+
+  var actual = recordStream.getIdPrefix(filename, basePath);
+
+  var expected = 'cz/countrywide';
+  test.equal(actual, expected, 'correct prefix generated');
+  test.end();
+});
+
+tape( 'getIdPrefix returns basename without extension when invalid basepath given - geojson', function( test ) {
+  var filename = '/path/to/a/document.geojson';
   var basePath = '/somewhere/else';
 
   var actual = recordStream.getIdPrefix(filename, basePath);


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:

The id of documents imported from GeoJSON contains `.geojson`. When we import csv, the extension is removed from the prefix. So I brought the functionality back to geojsons.

---
#### Here's how others can test the changes :eyes:

I added 3 tests based on CSV