### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y unzip awscli && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y unzip awscli && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/openaddresses
@@ -11,7 +11,7 @@ WORKDIR ${WORKDIR}
 
 # copy package.json first to prevent npm install being rerun when only code changes
 COPY ./package.json ${WORKDIR}
-RUN npm install
+RUN npm install && npm cache clean --force;
 
 # copy code into image
 ADD . ${WORKDIR}


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install`. It helps to reduce the size of the image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.


Impact on the image size:
* Image size before repair: 577.31 MB
* Image size after repair: 445.65 MB
* Difference: 131.65 MB (22.8%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,