### PR TITLE
docs: Add entry for oa token

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ This is useful, for example, when downloading from `s3://data.openaddresses.io`,
 as they require the requester to pay for data transfer.
 You can then use the following option: `--request-payer`
 
+### `imports.openaddresses.token`
+* Required: no
+* Default: Shared token for the pelias project
+
+Since openaddresses moved from [results.openaddresses.io](https://results.openaddresses.io) to [batch.openaddresses.org](https://batch.openaddresses.org), you need a token to access the data. There is a default shared token for the Pelias project, but if you want to use it seriously, create your own account and token on [batch.openaddresses.org. ](https://batch.openaddresses.org) to avaoid possible throttling/bandwidth limit or (temporary) suspension.
+
+
 ## Parallel Importing
 
 Because OpenAddresses consists of many small files, this importer can be configured to run several instances in parallel that coordinate to import all the data.


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
`imports.openaddresses.token` was an undocumented config parameter. To encourage users to use their own oa token the parameter should be documented.

---
#### Here's what actually got changed :clap:
- README.md

---
#### Here's how others can test the changes :eyes:
/
