### PR TITLE
fix: fixed openaddress batch website url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You can then use the following option: `--request-payer`
 * Required: no
 * Default: Shared token for the pelias project
 
-Since openaddresses moved from [results.openaddresses.io](https://results.openaddresses.io) to [batch.openaddresses.org](https://batch.openaddresses.org), you need a token to access the data. There is a default shared token for the Pelias project, but if you want to use it seriously, create your own account and token on [batch.openaddresses.org. ](https://batch.openaddresses.org) to avoid possible throttling/bandwidth limit or (temporary) suspension.
+Since openaddresses moved from [results.openaddresses.io](https://results.openaddresses.io) to [batch.openaddresses.io](https://batch.openaddresses.io), you need a token to access the data. There is a default shared token for the Pelias project, but if you want to use it seriously, create your own account and token on [batch.openaddresses.io. ](https://batch.openaddresses.io) to avoid possible throttling/bandwidth limit or (temporary) suspension.
 
 
 ## Parallel Importing


### PR DESCRIPTION
This pull request includes a minor documentation update to correct a URL in the `README.md` file. The update ensures that users are directed to the correct site for creating an account and obtaining a token.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R168): Corrected the URL from `batch.openaddresses.org` to `batch.openaddresses.io` to ensure users are directed to the appropriate site for creating an account and obtaining a token.