### PR TITLE
Node.js 18 Docker image and CI updates

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,5 +16,6 @@ jobs:
           node-version: '${{ matrix.node-version }}'
       - name: Run unit tests
         run: |
+          [[ -f ./bin/ci-setup ]] && ./bin/ci-setup
           npm install
           npm run ci

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,8 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version:
-          - 18.x
+        node-version: [ 18.x, 20.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,9 +8,6 @@ jobs:
         os:
           - ubuntu-22.04
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
           - 18.x
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ${{ vars.UBUNTU_VERSION }}
+          - ubuntu-22.04
         node-version:
           - 12.x
           - 14.x

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js
@@ -26,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ${{ vars.UBUNTU_VERSION }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
This PR includes a bunch of commits made by a script that standardizes as much as possible our CI config across all repositories.

Along the way it also ensures we test all Node.js versions that are an LTS release, not EOL, and currently work with this repository. Any Github Actions that were out of date or used old Node.js versions (checkout and setup-node `v2`) are also updated. The openaddresses importer and all others will need updated `whosonfirst` / `wof-admin-lookup` deps with a new version of `better-sqlite3` before we can add Node.js 22 support.

Also, the CI OS version is now hardcoded to ubuntu-22.04. We fooled around with an organization wide CI variable to configure that, but it broke CI in forks and doesn't really help us much, so it's now undone.

If there are any other differences in Github Actions Workflow files, they are also now removed by using a standard template.

Finally, because this repository has a Dockerfile and we just [updated the Docker baseimage to support Node.js 18](https://github.com/pelias/docker-baseimage/pull/29), there is an empty commit to trigger a new major version release.

Connects https://github.com/pelias/pelias/issues/950
Connects https://github.com/pelias/pelias/issues/951