### PR TITLE
Update pelias-wof-admin-lookup to v7.11.0

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
     steps:
       - uses: actions/checkout@v4
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pelias-dbclient": "^3.1.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^10.2.0",
-    "pelias-wof-admin-lookup": "^7.8.0",
+    "pelias-wof-admin-lookup": "^7.11.0",
     "split2": "^3.2.2",
     "temp": "^0.9.1",
     "through2": "^3.0.0",


### PR DESCRIPTION
This adds support for Node.js 22.

It also standardizes our wof-admin-lookup dependency version across importers, it had drifted a bit.

https://github.com/pelias/pelias/issues/950