### PR TITLE
Upgrade pelias-wof-admin-lookup to v7.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pelias-dbclient": "^3.1.0",
     "pelias-logger": "^1.2.1",
     "pelias-model": "^10.5.0",
-    "pelias-wof-admin-lookup": "^7.11.0",
+    "pelias-wof-admin-lookup": "^7.12.0",
     "split2": "^3.2.2",
     "temp": "^0.9.1",
     "through2": "^3.0.0",


### PR DESCRIPTION
Includes a fix for macroregions/region ordering from https://github.com/pelias/wof-admin-lookup/pull/325