### PR TITLE
Docker: Remove unused dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install --no-install-recommends -y unzip awscli && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y awscli && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/openaddresses


### PR DESCRIPTION
This removes the `unzip` package from the Docker image. It's already baked into our Pelias baseimage, so this change should have no impact.