### PR TITLE
feat(docker): Install `aws-cli` using the official installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install --no-install-recommends -y awscli && rm -rf /var/lib/apt/lists/*
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws
 
 # change working dir
 ENV WORKDIR /code/pelias/openaddresses


### PR DESCRIPTION
This reworks how we install the `aws` command line package, used by the OA downloader to fetch files from S3.

Previously we installed a normal `apt` package. In Ubuntu 24, there is no longer an official package for the AWS CLI. There's a `snap` package, but we probably don't want that.

AWS also maintains their own [official installer](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), which seems like a reasonable thing to use going forward.

This PR is the only known blocker of merging https://github.com/pelias/docker-baseimage/pull/32.